### PR TITLE
Avalanche Mini shrink middle protection

### DIFF
--- a/DTW/Avalanche_Mini/map.json
+++ b/DTW/Avalanche_Mini/map.json
@@ -113,7 +113,7 @@
 		{"id": "orange-hull", "type": "cuboid", "min": "-101, 34, -2", "max": "-83, 18, 2"},
 		{"id": "red-hull", "type": "cuboid", "min": "63, 34, 2", "max": "45, 18, -2" },
 
-		{"id": "middle-protection", "type": "cylinder", "base": "-19, 4, 0", "radius": "11", "height": "14"},
+		{"id": "middle-protection", "type": "cylinder", "base": "-19, 4, 0", "radius": "7", "height": "14"},
 		{"id": "elixir-protection-1", "type": "cylinder", "base": "-79, 7, -2", "radius": "3", "height": "6"},
 		{"id": "elixir-protection-2", "type": "cylinder", "base": "41, 7, 2", "radius": "3", "height": "6"},
 


### PR DESCRIPTION
Middle protection area on Avalanche mini was increased at some point preventing players from placing blocks anywhere on top of the outside ring of the center, which somehow kills people really often lmao

just doing this to make it so people die less from this for some reason

(I just made the radius 7 blocks long instead of 11 so it still protects the center circle, just not the ring around it)