### PR TITLE
Aerial Conquest itemremove issue fix

### DIFF
--- a/DTM/Aerial_Conquest/map.json
+++ b/DTM/Aerial_Conquest/map.json
@@ -87,7 +87,7 @@
 		}
 	],
 	"itemremove": [
-		"iron sword", "bow", "diamond pickaxe", "iron pickaxe", "arrow", "cooked beef",
+		"iron sword", "bow", "diamond pickaxe", "iron pickaxe", "arrow", "cooked beef", "blue stained glass", "red stained glass",
 		"leather helmet", "iron chestplate", "iron leggings", "leather boots"
 	],
 	"killstreaks": [

--- a/DTM/Aerial_Conquest/map.json
+++ b/DTM/Aerial_Conquest/map.json
@@ -87,7 +87,7 @@
 		}
 	],
 	"itemremove": [
-		"iron sword", "bow", "diamond pickaxe", "iron pickaxe", "arrow", "cooked beef", "blue stained glass", "red stained glass",
+		"iron sword", "bow", "diamond axe", "iron pickaxe", "arrow", "cooked beef", "blue stained glass", "red stained glass",
 		"leather helmet", "iron chestplate", "iron leggings", "leather boots"
 	],
 	"killstreaks": [


### PR DESCRIPTION
Adds stained glass blocks to the itemremove function.

Note that I'm not 100% sure this is the only issue with the itemremove function for Aerial Conquest. I just thought this might as well be implemented now rather than later when I figure everything else out.