### PR TITLE
Add / Fix kill rewards for maps in new rot

### DIFF
--- a/Blitz/Forsaken_Ruins/map.json
+++ b/Blitz/Forsaken_Ruins/map.json
@@ -59,6 +59,15 @@
 	],
 	"killstreaks": [
 		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "amount": 1}
+				]
+			}
+		},
+		{
 			"count": 2,
 			"repeat": true,
 			"actions": {

--- a/Blitz/No_Return/map.json
+++ b/Blitz/No_Return/map.json
@@ -46,6 +46,17 @@
 	"itemremove": [
 		"bow", "golden apple", "bread", "arrow", "leather helmet", "leather chestplate", "leather leggings", "iron boots"
 	],
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "amount": 1}
+				]
+			}
+		}
+	],
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["blue", "purple"],

--- a/DTM/Formorgar_1/map.json
+++ b/DTM/Formorgar_1/map.json
@@ -94,6 +94,17 @@
 	"itemremove": [
 		"iron sword", "bow", "diamond pickaxe", "stone axe", "oak planks", "golden apple", "cooked beef", "arrow",
 		"leather helmet", "chainmail chestplate", "leather leggings", "iron boots"
+	],
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "amount": 1}
+				]
+			}
+		}
 	],	
 	"filters": [
 		{

--- a/DTM/Senex_3/map.json
+++ b/DTM/Senex_3/map.json
@@ -98,7 +98,7 @@
 	],	
 	"killstreaks": [
 		{
-			"count": 2,
+			"count": 1,
 			"repeat": true,
 			"actions": {
 				"items": [

--- a/DTW/Oakley/map.json
+++ b/DTW/Oakley/map.json
@@ -73,6 +73,17 @@
 		"iron sword", "bow", "stone axe", "oak planks", "cooked beef", "arrow", "golden apple",
 		"leather helmet", "chainmail chestplate", "leather leggings", "iron boots"
 	],
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "amount": 1}
+				]
+			}
+		}
+	],
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["blue", "red"],

--- a/DTW/Stronghold/map.json
+++ b/DTW/Stronghold/map.json
@@ -87,7 +87,7 @@
 			}
 		},
 		{
-			"count": 5,
+			"count": 2,
 			"repeat": true,
 			"actions": {
 				"items": [


### PR DESCRIPTION
Correct any if im wrong please

for senex 3 i changed it to count 1 because you get killed easily on that map if you dont get kill rewards after one kill imo