### PR TITLE
Change rot order

### DIFF
--- a/rotation.txt
+++ b/rotation.txt
@@ -24,10 +24,10 @@ Aureola
 Senex 3
 Terrace 2
 Brisked KOTH
-Fracture
 Aerial Conquest
 Celestial
 Electri City
+Fracture
 Forsaken Ruins
 Timeless
 Avalanche Mini


### PR DESCRIPTION
Suggested rot change so two KOTH maps aren't played back to back.

I just threw Fracture anywhere in the rots, not sure if there was a previous system - if there would be a better place.