### PR TITLE
Add reasonable arrow reward amount on RFV2

### DIFF
--- a/CTW/Race_for_Victory_2/map.json
+++ b/CTW/Race_for_Victory_2/map.json
@@ -95,7 +95,7 @@
 			"actions": {
 				"items": [
 					{"material": "golden apple", "amount": 1},
-					{"material": "arrow", "amount": 1}
+					{"material": "arrow", "amount": 8}
 				]
 			}
 		}


### PR DESCRIPTION
How does 1 arrow make sense when you have a full stack? o.O