### PR TITLE
Cargo; Fix BuildHeight

### DIFF
--- a/CTW/Cargo/map.json
+++ b/CTW/Cargo/map.json
@@ -124,5 +124,5 @@
 		{ "id": "blue-spawn-protection", "type": "cuboid", "min": "61, 0, -34", "max": "66, oo, -51" },
 		{ "id": "red-spawn-protection", "type": "cuboid", "min": "61, 0, -176", "max": "66, oo, -193" }
 	],
-	"buildHeight": 71
+	"buildHeight": 105
 }


### PR DESCRIPTION
Same issue as Electri City, map was loaded on warzone higher than the source