### PR TITLE
RFV2; Fix spawn regions

### DIFF
--- a/CTW/Race_for_Victory_2/map.json
+++ b/CTW/Race_for_Victory_2/map.json
@@ -120,8 +120,8 @@
 		{"id": "purple-room", "min": "5, 0, 133", "max": "16, oo, 119"},
 		{"id": "yellow-room", "min": "-16, 0, 119", "max": "-5, oo, 133"},
 
-		{"id": "blue-spawn-protection", "type": "cuboid", "min": "-7, 0, -40", "max": "7, 9, -70"},
-		{"id": "red-spawn-protection", "type": "cuboid", "min": "-7, 0, 54", "max": "8, 9, 84"},
+		{"id": "blue-spawn-protection", "type": "cuboid", "min": "-14, 0, -65", "max": "15, 8, -41"},
+		{"id": "red-spawn-protection", "type": "cuboid", "min": "-14, 0, 56", "max": "15, 8, 80"},
 		{"id": "red-base-center", "type": "cuboid", "min": "-4, oo, 133", "max": "4, 0, 84"},
 		{"id": "blue-base-center", "type": "cuboid", "min": "-4, oo, -119", "max": "-4, 0, -70"},
 


### PR DESCRIPTION
Updated spawn regions to prevent spawn from being mined out - regions were too small.