### PR TITLE
Remove Build/Destroy Abilities

### DIFF
--- a/TDM/Golden_Gate/map.json
+++ b/TDM/Golden_Gate/map.json
@@ -51,5 +51,15 @@
 	],
 	"itemremove": [
 		"iron sword", "bow", "cooked beef", "arrow", "leather helmet", "chainmail chestplate", "iron leggings", "leather boots"
+	],
+	"filters": [
+		{
+			"type": "build", "evaluate": "deny", "teams": ["red", "blue"],
+			"regions": ["global"],
+			"message": "&cYou are not allowed to modify terrain here."
+		}
+	],
+	"regions": [
+		{"id": "global", "type": "cuboid", "min": "-oo, -oo, -oo", "max": "oo, oo, oo"}
 	]
 }


### PR DESCRIPTION
To prevent traps to be built, won't affect gameplay as no blocks or tools are in kits.

As an example, to prevent this; https://imgur.com/pgb7XEk