### PR TITLE
A New Day: Add wool spawner region

### DIFF
--- a/CTW/A_New_Day/map.json
+++ b/CTW/A_New_Day/map.json
@@ -1,131 +1,135 @@
 {
-	"name": "A New Day",
-	"authors": [
-		{"uuid": "b5071a63-bba3-491a-909f-02db314f4319", "username": "dcstarwars"},
-		{"uuid": "105f6a09-f533-412b-93cb-501601763c11", "username": "JTerwiesch"}
-	],
-	"version": "1.0.6",
-	"gametype": "CTW",
-	"teams": [
-		{
-			"id": "red",
-			"name": "Red",
-			"color": "red",
-			"min": 1,
-			"max": 50
-		},
-		{
-			"id": "blue",
-			"name": "Blue",
-			"color": "blue",
-			"min": 1,
-			"max": 50
-		}
-	],
-	"spawns": [
-		{"teams": ["spectators"], "coords": "-6.5, 22, 300.5, -180"},
-		{"teams": ["red"], "coords": "109.5, 8, 211.5, 90"},
-		{"teams": ["blue"], "coords": "-122.5, 8, 211.5, -90"}
-	],
-	"ctw": {
-		"wools": [
-			{
-				"name": "Lime",
-				"color": "green",
-				"woolcolor": "lime",
-				"teams": ["red"],
-				"region": {"min": "114, 9, 209", "max": "114, 9, 209"}
-			},
-			{
-				"name": "Purple",
-				"color": "dark purple",
-				"woolcolor": "purple",
-				"teams": ["red"],
-				"region": {"min": "114, 9, 213", "max": "114, 9, 213"}
-			},
-			{
-				"name": "Orange",
-				"color": "gold",
-				"woolcolor": "orange",
-				"teams": ["blue"],
-				"region": {"min": "-128, 9, 213", "max": "-128, 9, 213"}
-			},
-			{
-				"name": "Yellow",
-				"color": "yellow",
-				"woolcolor": "yellow",
-				"teams": ["blue"],
-				"region": {"min": "-128, 9, 209", "max": "-128, 9, 209"}
-			}
-		]
-	},
-	"kits": [
-		{
-			"name": "Default",
-			"items": [
-				{"material": "iron sword", "slot": 0, "unbreakable": true},
-				{"material": "bow", "slot": 1, "unbreakable": true},
-				{"material": "iron pickaxe", "slot": 2, "unbreakable": true},
-				{"material": "iron axe", "slot": 3, "unbreakable": true},
+    "name": "A New Day",
+    "authors": [
+        {"uuid": "b5071a63-bba3-491a-909f-02db314f4319", "username": "dcstarwars"},
+        {"uuid": "105f6a09-f533-412b-93cb-501601763c11", "username": "JTerwiesch"}
+    ],
+    "version": "1.0.6",
+    "gametype": "CTW",
+    "teams": [
+        {
+            "id": "red",
+            "name": "Red",
+            "color": "red",
+            "min": 1,
+            "max": 50
+        },
+        {
+            "id": "blue",
+            "name": "Blue",
+            "color": "blue",
+            "min": 1,
+            "max": 50
+        }
+    ],
+    "spawns": [
+        {"teams": ["spectators"], "coords": "-6.5, 22, 300.5, -180"},
+        {"teams": ["red"], "coords": "109.5, 8, 211.5, 90"},
+        {"teams": ["blue"], "coords": "-122.5, 8, 211.5, -90"}
+    ],
+    "ctw": {
+        "wools": [
+            {
+                "name": "Lime",
+                "color": "green",
+                "woolcolor": "lime",
+                "teams": ["red"],
+                "region": {"min": "114, 9, 209", "max": "114, 9, 209"}
+            },
+            {
+                "name": "Purple",
+                "color": "dark purple",
+                "woolcolor": "purple",
+                "teams": ["red"],
+                "region": {"min": "114, 9, 213", "max": "114, 9, 213"}
+            },
+            {
+                "name": "Orange",
+                "color": "gold",
+                "woolcolor": "orange",
+                "teams": ["blue"],
+                "region": {"min": "-128, 9, 213", "max": "-128, 9, 213"}
+            },
+            {
+                "name": "Yellow",
+                "color": "yellow",
+                "woolcolor": "yellow",
+                "teams": ["blue"],
+                "region": {"min": "-128, 9, 209", "max": "-128, 9, 209"}
+            }
+        ]
+    },
+    "kits": [
+        {
+            "name": "Default",
+            "items": [
+                {"material": "iron sword", "slot": 0, "unbreakable": true},
+                {"material": "bow", "slot": 1, "unbreakable": true},
+                {"material": "iron pickaxe", "slot": 2, "unbreakable": true},
+                {"material": "iron axe", "slot": 3, "unbreakable": true},
 
-				{"material": "oak log", "slot": 5, "amount": 64},
-				{"material": "golden apple", "slot": 7, "amount": 3},
-				{"material": "cooked beef", "slot": 8, "amount": 64},
-				{"material": "arrow", "slot": 9, "amount": 32},
+                {"material": "oak log", "slot": 5, "amount": 64},
+                {"material": "golden apple", "slot": 7, "amount": 3},
+                {"material": "cooked beef", "slot": 8, "amount": 64},
+                {"material": "arrow", "slot": 9, "amount": 32},
 
-				{"material": "leather chestplate", "slot": "chestplate", "unbreakable": true},
-				{"material": "chainmail leggings", "slot": "leggings", "unbreakable": true},
-				{"material": "leather boots", "slot": "boots", "unbreakable": true}
-			]
-		}
-	],
-	"itemremove": [
-		"iron sword", "bow", "iron pickaxe", "iron axe", "oak log", "oak planks", "golden apple", "cooked beef", "arrow",
-		"leather chestplate", "chainmail leggings", "leather boots"
-	],
-	"killstreaks": [
-		{
-			"count": 1,
-			"repeat": true,
-			"actions": {
-				"items": [
-					{"material": "golden apple", "amount": 1}
-				]
-			}
-		},
-		{
-			"count": 5,
-			"repeat": true,
-			"actions": {
-				"items": [
-					{"material": "arrow", "amount": 7}
-				]
-			}
-		}
-	],
-	"filters": [
-		{
-			"type": "build", "evaluate": "deny", "teams": ["red"],
-			"regions": ["red-spawn-protection", "blue-spawn-protection", "orange-room", "yellow-room"],
-			"message": "&cYou are not allowed to modify terrain here."
-		},
-		{
-			"type": "build", "evaluate": "deny", "teams": ["blue"],
-			"regions": ["red-spawn-protection", "blue-spawn-protection", "purple-room", "lime-room"],
-			"message": "&cYou are not allowed to modify terrain here."
-		},
-		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "lime-room", "purple-room"], "message": "&cYou may not enter this region."},
-		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "orange-room", "yellow-room"], "message": "&cYou may not enter this region."}
-	],
-	"regions": [
-		{"id": "yellow-room", "min": "79, 0, 106", "max": "109, oo, 135"},
-		{"id": "orange-room", "min": "79, 0, 287", "max": "109, oo, 316"},
+                {"material": "leather chestplate", "slot": "chestplate", "unbreakable": true},
+                {"material": "chainmail leggings", "slot": "leggings", "unbreakable": true},
+                {"material": "leather boots", "slot": "boots", "unbreakable": true}
+            ]
+        }
+    ],
+    "itemremove": [
+        "iron sword", "bow", "iron pickaxe", "iron axe", "oak log", "oak planks", "golden apple", "cooked beef", "arrow",
+        "leather chestplate", "chainmail leggings", "leather boots"
+    ],
+    "killstreaks": [
+        {
+            "count": 1,
+            "repeat": true,
+            "actions": {
+                "items": [
+                    {"material": "golden apple", "amount": 1}
+                ]
+            }
+        },
+        {
+            "count": 5,
+            "repeat": true,
+            "actions": {
+                "items": [
+                    {"material": "arrow", "amount": 7}
+                ]
+            }
+        }
+    ],
+    "filters": [
+        {
+            "type": "build", "evaluate": "deny", "teams": ["red"],
+            "regions": ["red-spawn-protection", "blue-spawn-protection", "orange-room", "yellow-room", "lime-spawner", "purple-spawner"],
+            "message": "&cYou are not allowed to modify terrain here."
+        },
+        {
+            "type": "build", "evaluate": "deny", "teams": ["blue"],
+            "regions": ["red-spawn-protection", "blue-spawn-protection", "purple-room", "lime-room", "yellow-spawner", "orange-spawner"],
+            "message": "&cYou are not allowed to modify terrain here."
+        },
+        {"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "lime-room", "purple-room"], "message": "&cYou may not enter this region."},
+        {"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "orange-room", "yellow-room"], "message": "&cYou may not enter this region."}
+    ],
+    "regions": [
+        {"id": "yellow-room", "min": "79, 0, 106", "max": "109, oo, 135"},
+        {"id": "yellow-spawner", "min": "94, 6, 121", "max": "94, 7, 121"},
+        {"id": "orange-room", "min": "79, 0, 287", "max": "109, oo, 316"},
+        {"id": "orange-spawner", "min": "94, 6, 301", "max": "94, 7, 301"},
 
-		{"id": "lime-room", "min": "-93, 0, 135", "max": "-123, oo, 106"},
-		{"id": "purple-room", "min": "-93, 0, 316", "max": "-123, oo, 287"},
+        {"id": "lime-room", "min": "-93, 0, 135", "max": "-123, oo, 106"},
+        {"id": "lime-spawner", "min": "-108, 6, 121", "max": "-108, 7, 121"},
+        {"id": "purple-room", "min": "-93, 0, 316", "max": "-123, oo, 287"},
+        {"id": "purple-spawner", "min": "-108, 6, 301", "max": "-108, 7, 301"},
 
-		{"id": "red-spawn-protection", "type": "cuboid", "min": "95, 0, 224", "max": "118, oo, 198"},
-		{"id": "blue-spawn-protection", "type": "cuboid", "min": "-109, 0, 198", "max": "-132, oo, 224"}
-	],
-	"buildHeight": 35
+        {"id": "red-spawn-protection", "type": "cuboid", "min": "95, 0, 224", "max": "118, oo, 198"},
+        {"id": "blue-spawn-protection", "type": "cuboid", "min": "-109, 0, 198", "max": "-132, oo, 224"}
+    ],
+    "buildHeight": 35
 }


### PR DESCRIPTION
Denies modifications of the wool spawner inside the wool rooms. Previosly, the wool spawner could be destroyed resulting in no more wool being spawned. This commit adds a region around the spawner and the beacon block above to prevent this.

Tested, as seen in the screenshot:
![2021-01-24_14 51 19](https://user-images.githubusercontent.com/7355350/105632590-430b2600-5e54-11eb-9183-c7d5945fb07a.png)
