### PR TITLE
Cloudy Domain: Add a build height

### DIFF
--- a/DTW/Cloudy_Domain/map.json
+++ b/DTW/Cloudy_Domain/map.json
@@ -98,5 +98,6 @@
 	"regions": [
 		{"id": "blue-spawn-protection", "type": "cuboid", "min": "160, 126, -35", "max": "146, oo, -49"},
 		{"id": "red-spawn-protection", "type": "cuboid", "min": "18, 126, -49", "max": "32, oo, -35"}
-	]
+	],
+	"buildHeight": 160
 }


### PR DESCRIPTION
Someone might want to double check if that's the right way to do this.

Also not sure this is something you guys want implemented, but not having a limit allows for teams to simply build to the world limit, and boat down on the objective. Once you break the little orb, you're encased and protected from enemy arrows while breaking the monument (the orb by the monument btw).

160 should be high enough up to clear the map's hills, while giving a little room to go slightly higher than. Honestly could go maybe 10 blocks more up if you feel like it's low - I kinda eye balled the number in the time between the match ending and the cycling.