### PR TITLE
Increase Stalactite Team Sizes

### DIFF
--- a/KOTH/Stalactite/map.json
+++ b/KOTH/Stalactite/map.json
@@ -14,14 +14,14 @@
 			"name": "Green",
 			"color": "green",
 			"min": 1,
-			"max": 12
+			"max": 50
 		},
 		{
 			"id": "red",
 			"name": "Red",
 			"color": "red",
 			"min": 1,
-			"max": 12
+			"max": 50
 		}
 	],
 	"spawns": [


### PR DESCRIPTION
It's in the Large rotation, yet only allows for up to 12 players per team. I increased it to 50 as it is the standard for Warzone maps.

Untested.