### PR TITLE
Twin Peaks: Add build height

### DIFF
--- a/DTW/Twin_Peaks/map.json
+++ b/DTW/Twin_Peaks/map.json
@@ -98,5 +98,6 @@
 	"regions": [
 		{"id": "blue-spawn-protection", "type": "cuboid", "min": "177, 0, -145", "max": "200, oo, -115"},
 		{"id": "red-spawn-protection", "type": "cuboid", "min": "17, 0, -114", "max": "-3, oo, -144"}
-	]
+	],
+	"buildHeight": 112
 }

--- a/DTW/Twin_Peaks/map.json
+++ b/DTW/Twin_Peaks/map.json
@@ -99,5 +99,5 @@
 		{"id": "blue-spawn-protection", "type": "cuboid", "min": "177, 0, -145", "max": "200, oo, -115"},
 		{"id": "red-spawn-protection", "type": "cuboid", "min": "17, 0, -114", "max": "-3, oo, -144"}
 	],
-	"buildHeight": 112
+	"buildHeight": 120
 }


### PR DESCRIPTION
Prevents players from building bridges that are too high, allows players to build a 2 block high wall at the highest peak of the map to avoid being hit by arrows