### PR TITLE
Update Electri City regions to prevent wool bridging

### DIFF
--- a/CTW/Electri_City/map.json
+++ b/CTW/Electri_City/map.json
@@ -107,16 +107,17 @@
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["red"],
-			"regions": ["blue-spawn-protection", "red-spawn-protection", "yellow-room", "orange-room"],
+			"regions": ["blue-spawn-protection", "blue-spawn-back-protection", "red-spawn-protection", "red-spawn-back-protection", "yellow-room", "orange-room"],
 			"message": "&cYou are not allowed to modify terrain here."
 		},
 		{
 			"type": "build", "evaluate": "deny", "teams": ["blue"],
-			"regions": ["red-spawn-protection", "blue-spawn-protection", "purple-room", "cyan-room"],
+			"regions": ["red-spawn-protection", "red-spawn-back-protection", "blue-spawn-protection", "blue-spawn-back-protection", "purple-room", "cyan-room"],
 			"message": "&cYou are not allowed to modify terrain here."
 		},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "orange-room", "yellow-room"], "message": "&cYou may not enter this region."},
-		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "purple-room", "cyan-room"], "message": "&cYou may not enter this region."}
+		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "purple-room", "cyan-room"], "message": "&cYou may not enter this region."},
+		{"type": "voidbuild", "evaluate": "deny", "teams": ["red", "blue"], "inverted": true, "regions": ["map"], "message": "&cYou may not build over the void."}
 	],
 	"regions": [
 		{"id": "orange-room", "min": "59, 0, 28", "max": "70, oo, 20"},
@@ -124,8 +125,12 @@
 		{"id": "purple-room", "min": "-56, 0, -17", "max": "-64, oo, -28"},
 		{"id": "cyan-room", "min": "-57, 0, 20", "max": "-68, oo, 28"},
 
-		{"id": "blue-spawn-protection", "type": "cuboid", "min": "-40, 0, 4", "max": "-57, oo, -4"},
-		{"id": "red-spawn-protection", "type": "cuboid", "min": "42, 0, 4", "max": "59, oo, -4"}
+		{"id": "blue-spawn-protection", "type": "cuboid", "min": "-39, 0, -5", "max": "-58, oo, 5"},
+		{"id": "red-spawn-protection", "type": "cuboid", "min": "41, 0, 5", "max": "60, oo, -5"},
+		{"id": "red-spawn-back-protection", "type": "cuboid", "min": "58, 0, 19", "max": "76, oo, -16"},		
+		{"id": "blue-spawn-back-protection", "type": "cuboid", "min": "-56, 0, -16", "max": "-78, oo, 20"},
+	
+		{"id": "map", "type": "cuboid", "min": "-64, 0, -43", "max": "66, oo, 28"}
 	],
 	"buildHeight": 87
 }

--- a/CTW/Electri_City/map.json
+++ b/CTW/Electri_City/map.json
@@ -107,13 +107,18 @@
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["red"],
-			"regions": ["blue-spawn-protection", "blue-spawn-back-protection", "red-spawn-protection", "red-spawn-back-protection", "yellow-room", "orange-room"],
+			"regions": ["blue-spawn-protection", "red-spawn-protection", "yellow-room", "orange-room"],
 			"message": "&cYou are not allowed to modify terrain here."
 		},
 		{
 			"type": "build", "evaluate": "deny", "teams": ["blue"],
-			"regions": ["red-spawn-protection", "red-spawn-back-protection", "blue-spawn-protection", "blue-spawn-back-protection", "purple-room", "cyan-room"],
+			"regions": ["red-spawn-protection", "blue-spawn-protection", "purple-room", "cyan-room"],
 			"message": "&cYou are not allowed to modify terrain here."
+		},
+		{
+			"type": "build", "evaluate": "deny", "teams": ["red", "blue"],
+			"regions": ["red-spawn-back-protection", "blue-spawn-back-protection"],
+			"message": "&cYou may not build over the void."
 		},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "orange-room", "yellow-room"], "message": "&cYou may not enter this region."},
 		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "purple-room", "cyan-room"], "message": "&cYou may not enter this region."},


### PR DESCRIPTION
- Slightly larger spawn protection
- Added void filter to prevent wall running on wool rooms
- Added "back protection" regions for each spawn to prevent bridging from one wool room to another

Tested: https://youtu.be/IFvXN2oJh3Q