### PR TITLE
Update Cargo regions & expand void filter on Electri City

### DIFF
--- a/CTW/Cargo/map.json
+++ b/CTW/Cargo/map.json
@@ -103,12 +103,12 @@
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["red"],
-			"regions": ["blue-spawn-protection", "red-spawn-protection", "purple-room", "cyan-room"],
+			"regions": ["blue-spawn-protection", "blue-spawn-top-protection", "red-spawn-protection", "red-spawn-top-protection", "purple-room", "cyan-room"],
 			"message": "&cYou are not allowed to modify terrain here."
 		},
 		{
 			"type": "build", "evaluate": "deny", "teams": ["blue"],
-			"regions": ["red-spawn-protection", "blue-spawn-protection", "yellow-room", "orange-room"],
+			"regions": ["red-spawn-protection", "red-spawn-top-protection", "blue-spawn-protection", "blue-spawn-top-protection", "yellow-room", "orange-room"],
 			"message": "&cYou are not allowed to modify terrain here."
 		},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "purple-room", "cyan-room"], "message": "&cYou may not enter this region."},
@@ -121,8 +121,13 @@
 		{"id": "purple-room", "min": "78, 0, -216", "max": "114, oo, -193"},
 		{"id": "cyan-room", "min": "13, 0, -216", "max": "49, oo, -193"},
 
-		{ "id": "blue-spawn-protection", "type": "cuboid", "min": "61, 0, -34", "max": "66, oo, -51" },
-		{ "id": "red-spawn-protection", "type": "cuboid", "min": "61, 0, -176", "max": "66, oo, -193" }
+		{ "id": "blue-spawn-protection", "type": "cuboid", "min": "54, 0, -32", "max": "73, oo, -51" },
+		{ "id": "red-spawn-protection", "type": "cuboid", "min": "54, 0, -176", "max": "73, oo, -199" },
+
+		{ "id": "blue-spawn-top-protection", "type": "cuboid", "min": "17, 92, -35", "max": "110, oo, -13" },
+		{ "id": "red-spawn-top-protection", "type": "cuboid", "min": "17, 92, -214", "max": "110, oo, -193" },
+
+		{ "id": "map", "type": "cuboid", "min": "30, 0, -199", "max": "97, oo, -28" }
 	],
 	"buildHeight": 105
 }

--- a/CTW/Cargo/map.json
+++ b/CTW/Cargo/map.json
@@ -129,5 +129,5 @@
 
 		{ "id": "map", "type": "cuboid", "min": "30, 0, -199", "max": "97, oo, -28" }
 	],
-	"buildHeight": 100
+	"buildHeight": 92
 }

--- a/CTW/Cargo/map.json
+++ b/CTW/Cargo/map.json
@@ -129,5 +129,5 @@
 
 		{ "id": "map", "type": "cuboid", "min": "30, 0, -199", "max": "97, oo, -28" }
 	],
-	"buildHeight": 105
+	"buildHeight": 100
 }

--- a/CTW/Electri_City/map.json
+++ b/CTW/Electri_City/map.json
@@ -115,11 +115,6 @@
 			"regions": ["red-spawn-protection", "blue-spawn-protection", "purple-room", "cyan-room"],
 			"message": "&cYou are not allowed to modify terrain here."
 		},
-		{
-			"type": "build", "evaluate": "deny", "teams": ["red", "blue"],
-			"regions": ["red-spawn-back-protection", "blue-spawn-back-protection"],
-			"message": "&cYou may not build over the void."
-		},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "orange-room", "yellow-room"], "message": "&cYou may not enter this region."},
 		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "purple-room", "cyan-room"], "message": "&cYou may not enter this region."},
 		{"type": "voidbuild", "evaluate": "deny", "teams": ["red", "blue"], "inverted": true, "regions": ["map"], "message": "&cYou may not build over the void."}
@@ -132,10 +127,8 @@
 
 		{"id": "blue-spawn-protection", "type": "cuboid", "min": "-39, 0, -5", "max": "-58, oo, 5"},
 		{"id": "red-spawn-protection", "type": "cuboid", "min": "41, 0, 5", "max": "60, oo, -5"},
-		{"id": "red-spawn-back-protection", "type": "cuboid", "min": "58, 0, 19", "max": "76, oo, -16"},		
-		{"id": "blue-spawn-back-protection", "type": "cuboid", "min": "-56, 0, -16", "max": "-78, oo, 20"},
 	
-		{"id": "map", "type": "cuboid", "min": "-64, 0, -43", "max": "66, oo, 28"}
+		{"id": "map", "type": "cuboid", "min": "-53, 0, -43", "max": "54, oo, 28"}
 	],
 	"buildHeight": 87
 }


### PR DESCRIPTION
- Extended spawn protection
- Add void filter to prevent wool-to-wool bridging
- Add "top-protection" region to prevent undefendable skybridges and/or escaping through the top of balloons
- Lower build height limit

Tested: https://www.youtube.com/watch?v=CFDRoopiwyc