### PR TITLE
Remove Infected from Large rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -101,7 +101,6 @@
 		"maps": [
 			"Race For Victory 2",
 			"Desert Country",
-			"Bayview",
 			"Outback",
 			"TechnoWar",
 			"Senex 3",
@@ -116,7 +115,6 @@
 			"Midnight Train",
 			"Aztec",
 			"Turf Wars",
-			"Neighborhood",
 			"Space Armarda",
 			"Urban Jungle",
 			"Mayan Apocalypse",


### PR DESCRIPTION
Infected is a gamemode which simply doesn't belong into a rotation. It should only be set under special circumstances. Having it be in Large rotation removes the uniqueness of the Infected gamemode. I think it originally was added to the Large rotation because the Large rotation would only very rarely play with the low amount of players we had on Warzone in the past months.

Infected maps should only be set by staff, to make sure it's not being played too often.