### PR TITLE
Change spawn protections to cylinder regions for Senex 3

### DIFF
--- a/DTM/Senex_3/map.json
+++ b/DTM/Senex_3/map.json
@@ -119,8 +119,8 @@
 		{"type": "enter", "evaluate": "deny", "teams": ["purple"], "regions": ["orange-spawn-protection"], "message": "&cYou may not enter the enemy spawn."}
 	],
 	"regions": [
-		{"id": "orange-spawn-protection", "type": "cuboid", "min": "30, 0, -872", "max": "43, oo, -886"},
-		{"id": "purple-spawn-protection", "type": "cuboid", "min": "121, 0, -872", "max": "134, oo, -886"}
+		{"id": "orange-spawn-protection", "type": "cylinder", "base": "36, 0, -879", "radius": 15, "height": 256 },
+		{"id": "purple-spawn-protection", "type": "cylinder", "base": "128, 0, -879", "radius": 15, "height": 256 }
 	],
 	"buildHeight": 30
 }


### PR DESCRIPTION
By using cylinder regions, both spawns are more appropriately protected from griefing and blocking.

Fixes #408 

Tested: https://youtu.be/_InqMrODjHU