### PR TITLE
Add void filter and lower build height limit on Race for Victory 2

### DIFF
--- a/CTW/Race_for_Victory_2/map.json
+++ b/CTW/Race_for_Victory_2/map.json
@@ -112,7 +112,8 @@
 			"message": "&cYou are not allowed to modify terrain here."
 		},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection", "purple-room", "yellow-room"], "message": "&cYou may not enter this region."},
-		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "lime-room", "orange-room"], "message": "&cYou may not enter this region."}
+		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection", "lime-room", "orange-room"], "message": "&cYou may not enter this region."},
+		{"type": "voidbuild", "evaluate": "deny", "teams": ["red", "blue"], "inverted": true, "regions": ["map"], "message": "&cYou may not build over the void."}
 	],
 	"regions": [
 		{"id": "lime-room", "min": "-5, oo, -119", "max": "-16, 0, -105"},
@@ -128,7 +129,9 @@
 		{"id": "base-left", "type": "cuboid", "min": "-17, 0, -119", "max": "-17, oo, 133"},
 		{"id": "base-right", "type": "cuboid", "min": "19, oo, 134", "max": "17, 0, -119"},
 		{"id": "blue-base-back", "type": "cuboid", "min": "17, 0, -120", "max": "-17, oo, -120"},
-		{"id": "red-base-back", "type": "cuboid", "min": "17, 0, 134", "max": "-17, oo, 134"}
+		{"id": "red-base-back", "type": "cuboid", "min": "17, 0, 134", "max": "-17, oo, 134"},
+		
+		{"id": "map", "type": "cuboid", "min": "-16, 0, -69", "max": "16, oo, 84"}
 	],
-	"buildHeight": 30
+	"buildHeight": 26
 }


### PR DESCRIPTION
- Add void filter to prevent building from one lane to the other
- Lower build height limit to match the height of the highest structure (spawn). A higher limit potentially allowed for towering from one lane and jumping to the other to get both wools.

Tested: https://youtu.be/5W04dMvO_PY