### PR TITLE
Fix Pluto JSON

### DIFF
--- a/Blitz/Pluto/map.json
+++ b/Blitz/Pluto/map.json
@@ -58,7 +58,7 @@
 				{"material": "iron boots", "slot": "boots", "unbreakable": true}
 			],
 			"effects": [
-				{"type": "damage resistance", "duration": 3, "amplifier": 50, "particles": false},
+				{"type": "damage resistance", "duration": 60, "amplifier": 50, "particles": false}
 			]
 		}
 	],


### PR DESCRIPTION
The JSON was invalid due to an extra comma. Also, effect durations are in ticks. 3 ticks are 150ms. I doubt the intention was to give the player damage resistance for only 150ms.