### PR TITLE
Cabin Fever II: Remove fishing rod

### DIFF
--- a/CTF/Cabin_Fever_II/map.json
+++ b/CTF/Cabin_Fever_II/map.json
@@ -71,9 +71,8 @@
 			"items": [
 				{"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
 				{"type": "item", "material": "bow", "slot": 1, "enchantments": ["infinity:1"], "unbreakable": true},
-				{"type": "item", "material": "fishing rod", "slot": 2, "unbreakable": true},
+				{"type": "item", "material": "golden apple", "slot": 2, "amount": 2},
 				{"type": "item", "material": "cooked beef", "slot": 3, "amount": 64},
-				{"type": "item", "material": "golden apple", "slot": 4, "amount": 2},
 				{"type": "item", "material": "arrow", "slot": 28},
 
 				{"type": "item", "material": "leather helmet", "slot": "helmet", "unbreakable": true},


### PR DESCRIPTION
Cabin Fever II shouldn't include a fishing rod within a player's starting inventory. Players with low ping can use a fishing rod to their advantage, while players with high ping are at an immediate disadvantage.