### PR TITLE
Gobi: Disable boat crafting

### DIFF
--- a/CTW/Gobi/map.json
+++ b/CTW/Gobi/map.json
@@ -106,6 +106,12 @@
 			}
 		}
 	],
+	"crafting": {
+		"remove": [
+			"oak boat",
+			"spruce boat"
+		]
+	},
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["red"],


### PR DESCRIPTION
Disable boat crafting - 1.16 users have an unfair advantage