### PR TITLE
Justice 2: Remove from medium rot

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -85,7 +85,6 @@
 			"Tranquility",
 			"Orion",
 			"Vortex",
-			"Justice 2",
 			"Palm Rust",
 			"Acromion"
 		]


### PR DESCRIPTION
Justice 2 seems a bit too big to be in the medium rotation, it should only be in the large rotation.