### PR TITLE
Palm Rust: Add iron axe to player loadout

### DIFF
--- a/DTM/Palm_Rust/map.json
+++ b/DTM/Palm_Rust/map.json
@@ -79,7 +79,8 @@
 				{"type": "item", "material": "iron sword", "slot": 0, "unbreakable": true},
 				{"type": "item", "material": "bow", "enchantments": ["infinity:1"], "slot": 1, "unbreakable": true},
 				{"type": "item", "material": "diamond pickaxe", "enchantments": ["efficiency:1"], "slot": 2, "unbreakable": true},
-				{"type": "item", "material": "iron shovel", "slot": 3, "unbreakable": true},
+				{"type": "item", "material": "iron axe", "slot": 3, "unbreakable": true},
+				{"type": "item", "material": "iron shovel", "slot": 4, "unbreakable": true},
 
 				{"type": "item", "material": "oak log", "slot": 5, "amount": 64},
 				{"type": "item", "material": "sandstone", "slot": 6, "amount": 64},


### PR DESCRIPTION
The primary building block on this map is wood, so it only makes sense for an iron axe to be added to starting loadouts.