### PR TITLE
Persisto: Add iron axe to player loadout

### DIFF
--- a/CTW/Persisto/map.json
+++ b/CTW/Persisto/map.json
@@ -67,10 +67,11 @@
 			"items": [
 				{"material": "stone sword", "slot": 0, "unbreakable": true},
 				{"material": "bow", "slot": 1, "unbreakable": true},
-				{"material": "iron pickaxe", "slot": 2, "unbreakable": true},
-				{"material": "glass", "slot": 3, "amount": 64},
+				{"material": "iron axe", "slot": 2, "unbreakable": true},
+				{"material": "iron pickaxe", "slot": 3, "unbreakable": true},
+				{"material": "glass", "slot": 4, "amount": 64},
 
-				{"material": "oak planks", "slot": 4, "amount": 64},
+				{"material": "oak planks", "slot": 5, "amount": 64},
 				{"material": "golden apple", "slot": 7, "amount": 1},
 				{"material": "cooked beef", "slot": 8, "amount": 32},
 				{"material": "arrow", "slot": 9, "amount": 64},

--- a/CTW/Persisto/map.json
+++ b/CTW/Persisto/map.json
@@ -67,7 +67,7 @@
 			"items": [
 				{"material": "stone sword", "slot": 0, "unbreakable": true},
 				{"material": "bow", "slot": 1, "unbreakable": true},
-				{"material": "iron axe", "slot": 2, "unbreakable": true},
+				{"material": "stone axe", "slot": 2, "unbreakable": true},
 				{"material": "iron pickaxe", "slot": 3, "unbreakable": true},
 				{"material": "glass", "slot": 4, "amount": 64},
 


### PR DESCRIPTION
Wood is placed all over this map, lacking an iron axe in your starting loadout is an inconvenience. 