### PR TITLE
Increase player limit on rampant to 15

### DIFF
--- a/CTF/Rampant/map.json
+++ b/CTF/Rampant/map.json
@@ -11,14 +11,14 @@
             "name": "Blue",
             "color": "blue",
             "min": 1,
-            "max": 12
+            "max": 15
         },
         {
             "id": "red",
             "name": "Red",
             "color": "dark red",
             "min": 1,
-            "max": 12
+            "max": 15
         }
     ],
     "spawns": [


### PR DESCRIPTION
Rampant is a med rot map and med rot can go up to 30 player so why make it a 12v12 and not a 15v15