### PR TITLE
Mushtastic: Add iron axe to player loadout

### DIFF
--- a/DTM/Mushtastic/map.json
+++ b/DTM/Mushtastic/map.json
@@ -58,11 +58,11 @@
 				{"type": "item", "material": "iron sword", "slot": 0, "unbreakable": true},
 				{"type": "item", "material": "bow", "slot": 1, "unbreakable": true},
 				{"type": "item", "material": "diamond pickaxe", "slot": 2, "unbreakable": true},
-
-				{"type": "item", "material": "oak planks", "slot": 3, "amount": 64},
+				{"type": "item", "material": "iron axe", "slot": 3, "unbreakable": true},
 
 				{"type": "item", "material": "oak planks", "slot": 4, "amount": 64},
-				
+				{"type": "item", "material": "oak planks", "slot": 5, "amount": 64},
+			
 				{"type": "item", "material": "cooked beef", "slot": 8, "amount": 64},
 				{"type": "item", "material": "arrow", "slot": 28, "amount": 64},
 


### PR DESCRIPTION
Loadout consists of 2 stacks of oak planks, an axe is essential.