### PR TITLE
Remove Vortex from medium rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -82,7 +82,6 @@
 			"SuperCUBE",
 			"Halcyon_I",
 			"Orion",
-			"Vortex",
 			"Palm Rust",
 			"Acromion",
 			"BlockRAGE"


### PR DESCRIPTION
Vortex is too small to be in the Medium rotation, it should only remain in the Small rotation.