### PR TITLE
Gyrus CTW: Lower build height

### DIFF
--- a/CTW/Gyrus_CTW/map.json
+++ b/CTW/Gyrus_CTW/map.json
@@ -213,5 +213,5 @@
 
 		{"id": "global", "type": "cuboid", "min": "-oo, -oo, -oo", "max": "oo, oo, oo"}
 	],
-	"buildHeight": 85
+	"buildHeight": 95
 }

--- a/CTW/Gyrus_CTW/map.json
+++ b/CTW/Gyrus_CTW/map.json
@@ -213,5 +213,5 @@
 
 		{"id": "global", "type": "cuboid", "min": "-oo, -oo, -oo", "max": "oo, oo, oo"}
 	],
-	"buildHeight": 160
+	"buildHeight": 85
 }


### PR DESCRIPTION
Lowers build height on Gyrus CTW to prevent high sky bridges and improve gameplay