### PR TITLE
Anasaria: Add build height

### DIFF
--- a/DTW/Anasaria/map.json
+++ b/DTW/Anasaria/map.json
@@ -135,5 +135,6 @@
 	"regions": [
 		{"id": "blue-spawn-protection", "type": "cuboid", "min": "58, 22, 46", "max": "35, oo, 28"},
 		{"id": "red-spawn-protection", "type": "cuboid", "min": "222, 22, 28", "max": "245, oo, 46"}
-	]
+	],
+	"buildHeight": 53
 }


### PR DESCRIPTION
Allows for adequate block placement on top of the highest peak of the map. Prevents high sky bridges.