### PR TITLE
Village KOTH: Increase point requirement

### DIFF
--- a/KOTH/Village_KOTH/map.json
+++ b/KOTH/Village_KOTH/map.json
@@ -27,7 +27,7 @@
 		{"teams": ["red"], "coords": "-3.5, 51, 72.5, 135"}
 	],
 	"points": {
-		"target": 350
+		"target": 500
 	},
 	"koth": {
 		"hills": [


### PR DESCRIPTION
Games typically end fast with a 350 point requirement, a requirement of 500 would be better. 
_This map isn't on the rotation but it is generally well received by players whenever it's queued on special occasions._