### PR TITLE
Halcyon I: Remove from medium rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -79,7 +79,6 @@
 			"Brisked KOTH",
 			"Concourse",
 			"SuperCUBE",
-			"Halcyon I",
 			"Orion",
 			"Abudor II",
 			"The High Road",


### PR DESCRIPTION
This map is not suitable for the medium rotation, it fills up way too fast with blocks and the islands are too small. Additionally, matches go for too long. 

Halcyon I should still be present in the small rotation for the time being. 