### PR TITLE
Concourse: Modify loadout

### DIFF
--- a/CTF/Concourse/map.json
+++ b/CTF/Concourse/map.json
@@ -64,8 +64,9 @@
 				{"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
 				{"type": "item", "material": "bow", "slot": 1, "unbreakable": true, "enchantments": ["infinity:1"]},
 				{"type": "item", "material": "golden carrot", "slot": 2, "amount": 64},
+				{"type": "item", "material": "golden apple", "slot": 3},
+				
 				{"type": "item", "material": "arrow", "slot": 28, "amount": 1},
-				{"type": "item", "material": "golden apple", "slot": 8},
 
 				{"type": "item", "material": "leather helmet", "slot": "helmet",  "unbreakable": true},
 				{"type": "item", "material": "iron chestplate", "slot": "chestplate", "unbreakable": true},


### PR DESCRIPTION
Players currently start the match with a golden apple in the 9th slot of their inventory. In the absence of a kit editor for this map, I have changed the golden apple to start in the 4th slot of your inventory.