### PR TITLE
Trenches: Add time limit, reduce captures

### DIFF
--- a/CTF/Trenches/map.json
+++ b/CTF/Trenches/map.json
@@ -27,11 +27,14 @@
         {"teams": ["red"], "coords": "28.5, 6, -76.5, 45"},
         {"teams": ["blue"], "coords": "-83.5, 6, 36.5, -135"}
     ],
-    "ctf": {
-        "objective": "amount",
-        "options": {
-            "captures": 3
-        },
+	"time": {
+		"limit": 1200
+	},
+	"ctf": {
+		"objective": "amount",
+		"options": {
+			"captures": 2
+		},
         "flags": [
             {
                 "team": "blue",


### PR DESCRIPTION
Added a time limit considering every CTF map has a 20 minute time limit. Reduced capture requirement to 2. 

