### PR TITLE
Egypt: Replace oak logs with oak planks

### DIFF
--- a/DTW/Egypt/map.json
+++ b/DTW/Egypt/map.json
@@ -57,7 +57,8 @@
 				{"type": "item", "material": "iron sword", "slot": 0, "unbreakable": true},
 				{"type": "item", "material": "bow", "slot": 1, "unbreakable": true},
 				{"type": "item", "material": "stone axe", "slot": 2, "unbreakable": true},
-				{"type": "item", "material": "oak log", "slot": 3, "amount": 64},
+				{"type": "item", "material": "oak planks", "slot": 3, "amount": 64},
+				{"type": "item", "material": "oak planks", "slot": 4, "amount": 64},
 				{"type": "item", "material": "cooked beef", "slot": 8, "amount": 64},
 				{"type": "item", "material": "arrow", "slot": 9, "amount": 24},
 


### PR DESCRIPTION
Replaced oak logs with 2 stacks of oak planks in starting loadout.
- Having to stop and craft logs into planks is inconvenient.
- Players don't need 4 stacks of oak planks, 2 should be enough.