### PR TITLE
Templum: Disable flint and steel crafting

### DIFF
--- a/DTW/Templum/map.json
+++ b/DTW/Templum/map.json
@@ -125,7 +125,6 @@
 	"crafting": {
 		"remove": [
 			"flint and steel",
-		]
     },
     "filters": [
         {

--- a/DTW/Templum/map.json
+++ b/DTW/Templum/map.json
@@ -122,6 +122,11 @@
             }
         }
     ],
+	"crafting": {
+		"remove": [
+			"flint and steel",
+		]
+    },
     "filters": [
         {
             "type": "build", "evaluate": "deny", "teams": ["yellow", "blue"],

--- a/DTW/Templum/map.json
+++ b/DTW/Templum/map.json
@@ -124,7 +124,8 @@
     ],
 	"crafting": {
 		"remove": [
-			"flint and steel",
+			"flint and steel"
+		]
     },
     "filters": [
         {


### PR DESCRIPTION
Team griefers can utilize flint and steel to burn bridges & set players on fire. There's no effective use for flint & steel if you're not a team griefer, so players should be prevented from crafting it.