### PR TITLE
Deepwind Jungle: Add stone shovel to loadout

### DIFF
--- a/CTW/Deepwind_Jungle/map.json
+++ b/CTW/Deepwind_Jungle/map.json
@@ -68,6 +68,7 @@
 				{"material": "bow", "slot": 1, "unbreakable": true},
 				{"material": "diamond pickaxe", "slot": 2, "unbreakable": true},
 				{"material": "iron axe", "slot": 3, "unbreakable": true},
+				{"material": "stone shovel", "slot": 30, "unbreakable": true},
 
 				{"material": "glass", "slot": 5, "amount": 64},
 				{"material": "oak planks", "slot": 6, "amount": 64},


### PR DESCRIPTION
Defenders can utilize stone shovels to efficiently mine out the ground in front of a wool room defensively. There is currently no space in the chests above spawn to allow shovels to be acquired, so it would be nice to have a stone shovel sitting in our inventory.

The stone shovel would not be placed in the hotbar, it would be placed in the 30th slot, on top of the iron axe. This keeps the hotbar clean, considering the only people who would be using a shovel for an effective purpose would be defenders.