### PR TITLE
Improve rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -8,7 +8,6 @@
 			"max": 14
 		},
 		"maps": [
-			"Senex",
 			"Ternio",
 			"Rooted",
 			"Twin Peaks",

--- a/rotation.json
+++ b/rotation.json
@@ -33,7 +33,8 @@
 			"Beckam",
 			"Timeless",
 			"Oakley",
-			"Warlock DTW"
+			"Warlock DTW",
+			"Windworks DTW"
 		]
 	},
 	{
@@ -75,20 +76,22 @@
 			"Kyoto",
 			"Ricco",
 			"Castles",
-			"Warlock",
 			"Sandstone 2",
 			"Arizona",
 			"Gardens",
 			"Deepwind Jungle",
 			"Brisked KOTH",
-			"Concourse",
 			"SuperCUBE",
 			"Orion",
 			"Abudor II",
 			"Outback",
 			"Aureola",
 			"Antiquis",
-			"Timeless"
+			"Timeless",
+			"Ring Race",
+			"Rendezvous Redux",
+			"Windworks DTW"
+			"Golden Drought III"
 		]
 	},
 	{
@@ -110,7 +113,6 @@
 			"TechnoWar",
 			"Senex 3",
 			"Terrace 2",
-			"Stalactite",
 			"Gyrus CTW",
 			"Ring Race",
 			"A New Day",
@@ -131,7 +133,7 @@
 			"Outback",
 			"Aztec FFA",
 			"Formorgar 2",
-			"Desert Sanctuary"
+			"Golden Drought III"
 		]
 	},
 	{

--- a/rotation.json
+++ b/rotation.json
@@ -30,7 +30,6 @@
 			"Halcyon I",
 			"Vortex",
 			"Beckam",
-			"Oakley",
 			"Warlock DTW"
 		]
 	},

--- a/rotation.json
+++ b/rotation.json
@@ -81,6 +81,7 @@
 			"Brisked KOTH",
 			"SuperCUBE",
 			"Orion",
+			"Concourse",
 			"Abudor II",
 			"Outback",
 			"Aureola",
@@ -129,7 +130,8 @@
 			"Outback",
 			"Aztec FFA",
 			"Formorgar 2",
-			"Golden Drought III"
+			"Golden Drought III",
+			"Desert Sanctuary"
 		]
 	},
 	{

--- a/rotation.json
+++ b/rotation.json
@@ -31,10 +31,8 @@
 			"Halcyon I",
 			"Vortex",
 			"Beckam",
-			"Timeless",
 			"Oakley",
-			"Warlock DTW",
-			"Windworks DTW"
+			"Warlock DTW"
 		]
 	},
 	{
@@ -87,10 +85,8 @@
 			"Outback",
 			"Aureola",
 			"Antiquis",
-			"Timeless",
 			"Ring Race",
 			"Rendezvous Redux",
-			"Windworks DTW"
 			"Golden Drought III"
 		]
 	},


### PR DESCRIPTION
## Rotation Improvements

#### Removed
- Warlock (DTM) 
**REASON:** Warlock consistently provides a 15-30 minute+ stalemate whenever it comes up on the rotation. A match on Warlock seems to constantly contain a large group of people struggling to cooperate in any way, ultimately leading to a cluster of wooden blocks in a defence, and contributing to a long match duration. Most players are engaging in a very long back & forth conflict, where it's typically just players running around the map doing absolutely nothing and filling the small map with blocks. Gameplay on this map is incredibly unappealing and it clogs up space on the rotation.

- Concourse (KOTF) & Desert Sanctuary (KOTF)
**REASON:** KOTF is not meant for Warzone in its current state. Flag carriers have no particle effects to show where they are, matches can easily become completely one sided, usually depending on whoever gets the flag first. Due to the lack of particle effects, flag carriers can very easily hide and not be caught, this is not competitive gameplay. Many new players complain that they can't respawn when their team has the flag, on competitive servers this is not an issue, but on Warzone this is seemed as a 'huge' inconvenience to most players, which lures them away from the server. When a player hides on a KOTF map and makes the gap between points very high, I sympathize with the players who are stuck waiting to respawn. 

- Stalactite (KOTH)
**REASON:** This is by far one of the most unappealing KOTH maps on Warzone. It's simply a large, FPS decreasing map that consists of players going back and forth between points over and over until the match finishes. The positioning of the points next to a teams spawn is also not ideal, you simply cannot hold that point if you're on the opposition, as the team who is closest to that point will simply run over and wipe everyone out, over and over again. 

#### Added
- Ring Race (CTW) [Medium Rotation]
**REASON:** This map is capable of being played in the Medium rotation.

- Rendezvous Redux (DTM)
**REASON:** This is a decent DTM map, and would be a good replacement for Warlock (DTM)

- Windworks DTW (DTW)
**REASON:** Windworks DTW has the potential to be an enjoyable map, there are not too many negative factors regarding this map except for the main route to the wool being through a tower. 

- Golden Drought III (CTW)
**REASON:** Great CTW map, good layout, decent gameplay. This should be added to the rotation unless it is still broken.


