### PR TITLE
Aztec FFA: Disable stats

### DIFF
--- a/FFA/Aztec/map.json
+++ b/FFA/Aztec/map.json
@@ -5,6 +5,7 @@
 	"authors": [
 		{"uuid": "07fa10c6-f564-4630-861e-fe134ae27527", "username": "Yoyo_"}
 	],
+	"stats": {"disable": true},
 	"teams": [
 		{
 			"id": "players", 


### PR DESCRIPTION
Stats shouldn't be tracked on an FFA map, I have seen no player who wanted stats to be enabled in the first place. As well, players spawn relatively close to each other, often leading to unnecessary deaths. 