### PR TITLE
No Return: Disable stats

### DIFF
--- a/Blitz/No_Return/map.json
+++ b/Blitz/No_Return/map.json
@@ -5,6 +5,7 @@
 	],
 	"gametype": "Blitz",
 	"version": "1.0",
+	"stats": {"disable": true},
 	"teams": [
 		{
 			"id": "purple",


### PR DESCRIPTION
There is no reason for this map to have stats enabled. Additionally, enabling stat tracking in the first place was not asked for by the community.