### PR TITLE
Desert Sanctuary: Lower time limit

### DIFF
--- a/CTF/Desert_Sanctuary/map.json
+++ b/CTF/Desert_Sanctuary/map.json
@@ -30,7 +30,7 @@
     "ctf": {
         "objective": "time",
         "options": {
-            "time": 720
+            "time": 420
         },
         "flags": [
             {


### PR DESCRIPTION
Desert Sanctuary currently lasts 10 minutes, there is a noticeable decrease in players during matches on this map, mainly due to the time limit. 

I have changed the time limit to 420 seconds (7 minutes) to make matches a bit faster and enjoyable. 