### PR TITLE
CherrylandMC: Prevent TNT from exploding spawn

### DIFF
--- a/DTM/CherrylandMC/map.json
+++ b/DTM/CherrylandMC/map.json
@@ -146,6 +146,10 @@
 			"type": "build", "evaluate": "deny", "teams": ["red", "blue"],
 			"regions": ["chests"],
 			"message": "&cYou may not physically edit the TNT chests."
+		},
+		{
+			"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"],
+			"regions": ["blue-spawn-protection", "red-spawn-protection"],
 		}
 	],
 	"regions": [

--- a/DTM/CherrylandMC/map.json
+++ b/DTM/CherrylandMC/map.json
@@ -149,7 +149,7 @@
 		},
 		{
 			"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"],
-			"regions": ["blue-spawn-protection", "red-spawn-protection"],
+			"regions": ["blue-spawn-protection", "red-spawn-protection"]
 		}
 	],
 	"regions": [


### PR DESCRIPTION
TNT can currently reach a teams spawn if enough of it is placed on the surrounding islands. This pull request should fix that.