### PR TITLE
Prevent TNT from destroying blocks in Outbreak

### DIFF
--- a/KOTH/Outbreak/map.json
+++ b/KOTH/Outbreak/map.json
@@ -80,14 +80,21 @@
 		"mobGriefing": false
 	},
 	"filters": [
-		{"type": "build", "evaluate": "deny", "teams": ["blue", "red"], "regions": ["global"], "message": "&cYou are not allowed to modify terrain here."},
-		{"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"], "regions": ["global"], "message": "&cYou are not allowed to modify terrain here."},
+		{
+			"type": "build", "evaluate": "deny", "teams": ["blue", "red"], 
+			"regions": ["global"], 
+			"message": "&cYou are not allowed to modify terrain here."
+		},
+		{
+			"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"], 
+			"regions": ["global"], 
+			"message": "&cYou are not allowed to modify terrain here."
+		},
 		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection"], "message": "&cYou may not enter the enemy spawn."}
 	],
 	"regions": [
 		{"id": "blue-spawn-protection", "min": "-37,27,1435", "max": "-31, 32, 1430"},
-		{"id": "red-spawn-protection", "min": "-31,27,1479", "max": "-37, 32, 1484"},
-		{"id": "global", "type": "cuboid", "min": "-oo, -oo, -oo", "max": "oo, oo, oo"}
+		{"id": "red-spawn-protection", "min": "-31,27,1479", "max": "-37, 32, 1484"}
 	]
 }

--- a/KOTH/Outbreak/map.json
+++ b/KOTH/Outbreak/map.json
@@ -81,6 +81,7 @@
 	},
 	"filters": [
 		{"type": "build", "evaluate": "deny", "teams": ["blue", "red"], "regions": ["global"], "message": "&cYou are not allowed to modify terrain here."},
+		{"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"], "regions": ["global"], "message": "&cYou are not allowed to modify terrain here."},
 		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection"], "message": "&cYou may not enter the enemy spawn."}
 	],


### PR DESCRIPTION
Hopefully, this deals with the grief that keeps happening on this map.