### PR TITLE
Add time limits to Staff vs Players event maps

### DIFF
--- a/CTW/A_New_Day/map.json
+++ b/CTW/A_New_Day/map.json
@@ -27,6 +27,9 @@
         {"teams": ["red"], "coords": "109.5, 8, 211.5, 90"},
         {"teams": ["blue"], "coords": "-122.5, 8, 211.5, -90"}
     ],
+    "time": {
+        "limit": 1800
+    },
     "ctw": {
         "wools": [
             {

--- a/CTW/Aequabilis/map.json
+++ b/CTW/Aequabilis/map.json
@@ -28,6 +28,9 @@
 		{"teams": ["green"], "coords": "-133, 67, 282, 90"},
 		{"teams": ["green"], "coords": "-133, 67, 275, 90"}
 	],
+	"time": {
+		"limit": 1800
+	},
 	"ctw": {
 		"wools": [
 			{

--- a/CTW/Fourchette/map.json
+++ b/CTW/Fourchette/map.json
@@ -28,6 +28,9 @@
 		{"teams": ["red"], "coords": "149.5, 7, 184.5, 90"},
 		{"teams": ["blue"], "coords": "-30.5, 7, 184.5, -90"}
 	],
+	"time": {
+		"limit": 1800
+	},
 	"ctw": {
 		"wools": [
 			{

--- a/CTW/Sandy Paradise/map.json
+++ b/CTW/Sandy Paradise/map.json
@@ -27,6 +27,9 @@
 		{"teams": ["cyan"], "coords": "-128.5, 73, 0.5, -90, 0"},
 		{"teams": ["green"], "coords": "129.5, 73, 0.5, 90, 0"}
 	],
+	"time": {
+		"limit": 1800
+	},
 	"ctw": {
 		"wools": [
 			{

--- a/DTM/Senex_3/map.json
+++ b/DTM/Senex_3/map.json
@@ -27,6 +27,9 @@
 		{"teams": ["orange"], "coords": "36.5, 18, -878.5, 90"},
 		{"teams": ["purple"], "coords": "128.5, 18, -878.5, -90"}
 	],
+	"time": {
+		"limit": 1800
+	},
 	"dtm": {
 		"monuments": [
 			{

--- a/DTW/Itty_Bitty/map.json
+++ b/DTW/Itty_Bitty/map.json
@@ -27,6 +27,9 @@
 		{"teams": ["red"], "coords": "-1.5, 23, 32.5, -90"},
 		{"teams": ["blue"], "coords": "26.5, 23, 32.5, 90"}
 	],
+	"time": {
+		"limit": 600
+	},
 	"dtm": {
 		"monuments": [
 			{

--- a/KOTH/Itty_Bitty_KOTH/map.json
+++ b/KOTH/Itty_Bitty_KOTH/map.json
@@ -28,6 +28,9 @@
 		{"teams": ["blue"], "coords": "-74.5, 2, 0.5, -90"},
 		{"teams": ["red"], "coords": "75.5, 2, 0.5, 90"}
 	],
+	"time": {
+		"limit": 600
+	},
 	"points": {
 		"target": 600
 	},


### PR DESCRIPTION
The changes produced by this PR will be reverted once the Staff vs Players event has finished.
Only two maps did not suffer changes: Crossfire and Shave Vice.
This is because their nature of gameplay. A time limit on Crossfire would encourage camping by runners and one on Shave Vice will likely not be enough due to the large amount of monuments (wools) required to win.