### PR TITLE
Add Sandy Paradise to Large rotation. and remove it from the medium rot

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -43,7 +43,6 @@
 		},
 		"maps": [
 			"Museum",
-                        "Sandy Paradise",
 			"CherrylandMC",
 			"Volitare Terras",
 			"Warlock DTW",
@@ -110,6 +109,7 @@
                         "Circulus Turres",
 			"TechnoWar",
 			"Senex 3",
+                        "Sandy Paradise",
 			"Terrace 2",
 			"Gyrus CTW",
 			"Ring Race",


### PR DESCRIPTION

Players are complaining that the map is way too big to be placed in the Medium Rotation Instead of the large one.