### PR TITLE
Remove piston from crafting pool [Templum]

### DIFF
--- a/DTW/Templum/map.json
+++ b/DTW/Templum/map.json
@@ -125,6 +125,7 @@
 	"crafting": {
 		"remove": [
 			"flint and steel"
+			"piston"
 		]
     },
     "filters": [

--- a/DTW/Templum/map.json
+++ b/DTW/Templum/map.json
@@ -124,7 +124,7 @@
     ],
 	"crafting": {
 		"remove": [
-			"flint and steel"
+			"flint and steel",
 			"piston"
 		]
     },


### PR DESCRIPTION
Players are able to craft pistons and use them in such a way that it would guarantee a lossless game for their team.
Anticipated result of this exploit will either result in a win for the team that does this or an indefinite stalemate.
![image](https://user-images.githubusercontent.com/80069984/129498495-8efd6cb5-89b6-4083-894d-11a22eac5c22.png)
