### PR TITLE
Remove Beckam from the rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -29,7 +29,6 @@
 			"Deepwind Jungle",
 			"Halcyon I",
 			"Vortex",
-			"Beckam",
 			"Warlock DTW"
 		]
 	},


### PR DESCRIPTION
Beckam should be removed from the rotation because there are too many instances of a drawn-out match between only 6 people. Whenever this map is played, there is typically barely anybody online, and it clogs up the rotation. The objective of the map is to reach 50 kills before the other team does. Additionally, I have never seen any positive comments about this map when it arrives on the rotation. 