### PR TITLE
Fix players dropping additional golden apples in Supercube

### DIFF
--- a/CTF/SuperCUBE/map.json
+++ b/CTF/SuperCUBE/map.json
@@ -111,7 +111,7 @@
 		}
 	],
 	"itemremove": [
-		"iron sword", "bow", "arrow", "potion", "glass bottle", "iron leggings",
+		"iron sword", "bow", "arrow", "potion", "glass bottle", "iron leggings", "golden apple",
 		{
 			"type": "leather chestplate",
 			"death": true,


### PR DESCRIPTION
If a player had golden apples from previous kills, they dropped them all when they died, instead of only giving one to reward the killer.