### PR TITLE
Add / fix killstreak rewards for maps with classes

### DIFF
--- a/DTW/Bridges/map.json
+++ b/DTW/Bridges/map.json
@@ -50,6 +50,17 @@
 			}
 		]
 	},
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "unbreakable": true, "amount": 1}
+				]
+			}
+		}
+	],
 	"classes": true,
 	"filters": [
 		{

--- a/DTW/Heaven/map.json
+++ b/DTW/Heaven/map.json
@@ -91,7 +91,7 @@
 			"repeat": true,
 			"actions": {
 				"items": [
-					{"material": "golden apple", "amount": 1}
+					{"material": "golden apple", "unbreakable": true, "amount": 1}
 				]
 			}
 		}

--- a/DTW/Rainbow/map.json
+++ b/DTW/Rainbow/map.json
@@ -70,6 +70,17 @@
 			}
 		]
 	},
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "unbreakable": true, "amount": 1}
+				]
+			}
+		}
+	],
 	"classes": true,
 	"itemremove": [
 		"iron sword", "bow", "iron axe", "oak planks", "arrow", "cooked beef", "golden apple",

--- a/DTW/Village/map.json
+++ b/DTW/Village/map.json
@@ -70,6 +70,17 @@
 			}
 		]
 	},
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "unbreakable": true, "amount": 1}
+				]
+			}
+		}
+	],
 	"classes": true,
 	"filters": [
 		{

--- a/KOTH/Village_KOTH/map.json
+++ b/KOTH/Village_KOTH/map.json
@@ -73,7 +73,7 @@
 			"repeat": true,
 			"actions": {
 				"items": [
-					{"material": "golden apple", "amount": 1}
+					{"material": "golden apple", "unbreakable": true, "amount": 1}
 				]
 			}
 		}


### PR DESCRIPTION
I have added golden apple kill rewards to maps that do not currently have them. All golden apples gained from killstreak rewards will now be 'unbreakable', as classes automatically put an unbreakable golden apple into your starting loadout. This is to allow golden apples to be stacked together, rather than having one unbreakable apple and one non-unbreakable apple in your inventory.
