### PR TITLE
Players drop golden apples on CherrylandMC

### DIFF
--- a/DTM/CherrylandMC/map.json
+++ b/DTM/CherrylandMC/map.json
@@ -97,7 +97,7 @@
 	],
 	"itemremove": [
 		"iron sword", "bow", "diamond pickaxe",
-		"oak log", "cooked beef", "arrow",
+		"oak log", "cooked beef", "arrow", "golden apple",
 		{
 			"type": "leather helmet",
 			"drop": true

--- a/DTM/CherrylandMC/map.json
+++ b/DTM/CherrylandMC/map.json
@@ -4,7 +4,7 @@
 		{"uuid": "bf331953-4f92-43ee-8abc-7544b8234936", "username": "Vicei"},
 		{"uuid": "916c8d6f-12d3-4a23-8553-d3ddcfcd248c", "username": "jeresl99"}
 	],
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"gametype": "DTM",
 	"teams": [
 		{


### PR DESCRIPTION
You already spawn with three golden apples so having players drop them on kill is way too powerful and definitely unintended