### PR TITLE
Itemremove diamond armor (inside wool room chests)

### DIFF
--- a/CTW/Persisto/map.json
+++ b/CTW/Persisto/map.json
@@ -6,7 +6,7 @@
 		{"uuid": "cbd0da49-26ac-46ef-b91d-47c2bb8d23bd", "username": "re_cel"},
 		{"uuid": "b0900577-7604-4dc7-9e82-f431da31e456", "username": "Dracoheart2"}
 	],
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"gametype": "CTW",
 	"teams": [
 		{

--- a/CTW/Persisto/map.json
+++ b/CTW/Persisto/map.json
@@ -85,7 +85,7 @@
 	],
 	"itemremove": [
 		"stone sword", "bow", "iron pickaxe", "glass", "oak planks", "golden apple", "cooked beef", "arrow",
-		"chainmail chestplate", "iron boots", "stone axe",
+		"chainmail chestplate", "iron boots", "stone axe", "diamond chestplate", "diamond boots",
 		{
             "type": "leather helmet",
             "death": true,


### PR DESCRIPTION
Diamond chest-plates and diamond boots can be found in the wool room chests on Persisto. Players aren't intended to drop items found in chest rooms.