### PR TITLE
Halcyon I: Remove efficiency from diamond pickaxes

### DIFF
--- a/DTM/Halcyon_I/map.json
+++ b/DTM/Halcyon_I/map.json
@@ -76,7 +76,7 @@
 			"items": [
 				{"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
 				{"type": "item", "material": "bow", "slot": 1, "unbreakable": true},
-				{"type": "item", "material": "diamond pickaxe", "enchantments": ["efficiency:1"], "slot": 2, "unbreakable": true},
+				{"type": "item", "material": "diamond pickaxe", "slot": 2, "unbreakable": true},
 				{"type": "item", "material": "stone axe", "slot": 3, "unbreakable": true},
 
 				{"type": "item", "material": "apple", "slot": 4, "amount": 64},


### PR DESCRIPTION
Diamond pickaxes should not have efficiency on Halcyon I. This map is known to have a lack of defenders, mainly due to the small size of the monument's island. If a player happens to reach the monument, it's incredibly rare that people would be able to get over there in time; meaning that there's essentially no reason for Efficiency 1 to exist on this map. 