### PR TITLE
Dodgeball TEST: Upgrade bows to power 100

### DIFF
--- a/CTF/Dodgeball_TEST/map.json
+++ b/CTF/Dodgeball_TEST/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "811968c3-0a9f-4cb5-80af-19ce37141341", "username": "BennyDoesStuff"}
 	],
-	"version": "0.1",
+	"version": "0.2",
 	"stats": {"disable": true},
 	"gametype": "KOTF",
 	"teams": [


### PR DESCRIPTION
As bow damage on TGM is inconsistent, it would be ideal to upgrade bows to power 100 on Dodgeball Test. This provides a fair experience for all players, since a power 5 bow cannot always kill somebody in one hit.  

This also makes damage consistent, since the bow currently has Sharpness 100. 