### PR TITLE
Move Babylon to the Large rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -54,7 +54,6 @@
 			"Ascension",
 			"Aureola",
 			"Autunno",
-			"Babylon",
 			"Bloody Trident",
 			"Brisked KOTH",
 			"Cargo",
@@ -111,6 +110,7 @@
 		},
 		"maps": [
 			"A New Day",
+			"Babylon",
 			"Bloody Trident",
 			"Cake CTW",
 			"Celestial",


### PR DESCRIPTION
Babylon should be moved to the Large rotation as the map is simply too small to be played in the Medium rotation. 