### PR TITLE
Remove Haunted Corridors from the Medium rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -70,7 +70,6 @@
 			"Gardens",
 			"Golden Drought III",
 			"Halloween Terras",
-			"Haunted Corridors",
 			"Haunted Hallows",
 			"Haunted Rings",
 			"Haunted Turres",


### PR DESCRIPTION
Haunted Corridors is way too big to be played on the Medium rotation, matches are often at risk of losing a lot of players, which can lead to very small player counts attempting to reach 50 kills on a big map. 

This is not suitable for the Medium rotation even when there 7 players on each team. 

_Note: This map would still be on the Large rotation_