### PR TITLE
Golden Drought III: Improve spawn regions

### DIFF
--- a/CTW/Golden Drought III/map.json
+++ b/CTW/Golden Drought III/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "459fd919-0d58-401a-9601-6cab1eb721ab", "username": "Reshif"}
 	],
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"gametype": "CTW",
 	"teams": [
 		{


### PR DESCRIPTION
This pull request prevents players from placing blocks on the roof inside of their spawn tunnel. 

I also removed two duplicate spawn protection lines. 