### PR TITLE
Remove Soviet Chills from the Medium rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -86,7 +86,6 @@
 			"Sandstone",
 			"Scarescape",
 			"Senex 3",
-			"Soviet Chills",
 			"Spooky",
 			"Stronghold",
 			"SuperCUBE",


### PR DESCRIPTION
Soviet Chills is too big to be played in the Medium rotation, it should only be in the Large rotation.