### PR TITLE
Remove Autunno from the Small rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -10,7 +10,6 @@
 		"maps": [
 			"Ancient Cistern",
 			"Arizona",
-			"Autunno",
 			"Balloons Halloween",
 			"Cargo",
 			"Deepwind Jungle",


### PR DESCRIPTION
Autunno shouldn't be played in the Small rotation, it seems much more suitable to only be in the Medium rotation.

![image](https://user-images.githubusercontent.com/55336990/137649271-a24ba01a-fdd3-42de-a632-068145c5413c.png)
