### PR TITLE
Disable iron axe from dropping on death (CherrylandMC)

### DIFF
--- a/DTM/CherrylandMC/map.json
+++ b/DTM/CherrylandMC/map.json
@@ -4,7 +4,7 @@
 		{"uuid": "bf331953-4f92-43ee-8abc-7544b8234936", "username": "Vicei"},
 		{"uuid": "916c8d6f-12d3-4a23-8553-d3ddcfcd248c", "username": "jeresl99"}
 	],
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"gametype": "DTM",
 	"teams": [
 		{


### PR DESCRIPTION
- Added iron axe to itemremove to disable it from dropping on death.