### PR TITLE
Keipha CTW: Upgrade damage resistance to 6 seconds

### DIFF
--- a/CTW/Keipha CTW/map.json
+++ b/CTW/Keipha CTW/map.json
@@ -14,7 +14,7 @@
             "username": "Strangey"
         }
     ],
-    "version": "1.1.1",
+    "version": "1.1.2",
     "gametype": "CTW",
     "teams": [
         {
@@ -196,7 +196,7 @@
             "effects": [
                 {
                     "type": "DAMAGE_RESISTANCE",
-                    "duration": 80,
+                    "duration": 120,
                     "amplifier": 25,
                     "particles": false
                 }


### PR DESCRIPTION
This pull requests changes how long players have resistance for when they spawn in. Changing the time from 4 seconds to 6 seconds can help to provide some extra time to account for lag spikes, ensuring that players typically cannot die upon spawning in (when you spawn, you drop down)