### PR TITLE
Remove Bloody Trident from Medium Rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -53,7 +53,6 @@
 			"Ascension",
 			"Aureola",
 			"Autunno",
-			"Bloody Trident",
 			"Brisked KOTH",
 			"Cargo",
 			"Castles",


### PR DESCRIPTION
Bloody Trident can come up in the Medium rotation when there are still not a lot of people online, this leads to reasonably small player counts competing on a quite large map. To avoid this, it should only be in the Large rotation, where a big player count is guaranteed. 