### PR TITLE
Cozy Cove: Add golden apple kill reward

### DIFF
--- a/Blitz/Cozy Cove/map.json
+++ b/Blitz/Cozy Cove/map.json
@@ -5,7 +5,7 @@
 		{"uuid": "edbd4cdb-63a5-4cec-944c-2b6bda56f51f", "username": "Owehttamy"}
 	],
 	"gametype": "Blitz",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"stats": {"disable": true},
 	"gamerules": {
 		"logAdminCommands": false,


### PR DESCRIPTION
Cozy Cove would play better if players had more regeneration. This pull request provides players with golden apples when they kill a player. If this is not enough; an instant regeneration effect would be great as an alternative.