### PR TITLE
Implement block-explode filter for Iris DTM

### DIFF
--- a/DTM/Iris DTM/map.json
+++ b/DTM/Iris DTM/map.json
@@ -154,7 +154,7 @@
         {
             "type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"],
             "regions": ["beacon-prot"]
-        },
+        }
     ],
     "regions": [
         {"id": "red-spawn-pool", "type": "cuboid", "min": "33, 26, -93", "max": "26, oo, -86"},

--- a/DTM/Iris DTM/map.json
+++ b/DTM/Iris DTM/map.json
@@ -150,7 +150,11 @@
             "inverted": true,
             "regions": ["map"],
             "message": "&cYou may not build/modify here!"
-        }
+        },
+        {
+            "type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"],
+            "regions": ["beacon-prot"]
+        },
     ],
     "regions": [
         {"id": "red-spawn-pool", "type": "cuboid", "min": "33, 26, -93", "max": "26, oo, -86"},


### PR DESCRIPTION
After the transition to coal blocks, the monuments can be destroyed by TNT without ending the game. 
A quick edit should resolve this.