### PR TITLE
Remove Coral Reef from the Small rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -47,7 +47,6 @@
 			"Arizona",
 			"Balloons",
 			"Cargo",
-			"Coral Reef",
 			"Deepwind Jungle",
 			"Desolate Gully",
 			"Downforce",


### PR DESCRIPTION
Coral Reef is too big to support a match with under 15 players, and especially considering small rotation matches can end up being 3v3s or similar, it's definitely not suitable.