### PR TITLE
Rooted CTW - Fix a spot where players can get stuck

### DIFF
--- a/CTW/Rooted CTW/map.json
+++ b/CTW/Rooted CTW/map.json
@@ -3,7 +3,7 @@
     "authors": [
         {"uuid": "fe3608b7-d105-4029-8800-34b3147065b6", "username": "rockymine"}
     ],
-    "version": "2.2.2",
+    "version": "2.2.3",
     "gametype": "CTW",
     "teams": [
         {


### PR DESCRIPTION
There's a block in the wool rooms above the ladders that can get players stuck due to the 1.14 crouching mechanics and 1.8 players nonsense.
Regardless it was a tiny change and now it can be fixed. (Only one block was modified in each room)