### PR TITLE
Monument Modes - Change SFX for 1.8 parity

### DIFF
--- a/DTM/Antiquis Christmas/map.json
+++ b/DTM/Antiquis Christmas/map.json
@@ -4,13 +4,13 @@
 		{"uuid": "060baa18-2852-40d8-afcb-e61607c04be3", "username": "PepsiDog"},
 		{"uuid": "571c1d9d-4d49-43bd-bfdb-30563e920ca9", "username": "__iMan"}
 	],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"gametype": "DTM",
 	"teams": [
 		{
 			"id": "green",
 			"name": "Green",
-			"color": "dark_green",
+			"color": "dark green",
 			"min": 1,
 			"max": 16
 		},
@@ -137,7 +137,7 @@
 				"commands": [
 					"execute at @r run fill 0 8 -41 0 9 -41 minecraft:beacon replace minecraft:obsidian",
 					"execute at @r run fill 0 8 41 0 9 41 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 0 11 0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 11 0 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 11 0 100 1"]},
@@ -152,7 +152,7 @@
 				"commands": [
 					"execute at @r run fill 0 8 -41 0 9 -41 minecraft:coal_block replace minecraft:beacon",
 					"execute at @r run fill 0 8 41 0 9 41 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 0 11 0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 11 0 100 0"
 				]
 			}
 		]

--- a/DTM/Antiquis/map.json
+++ b/DTM/Antiquis/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "060baa18-2852-40d8-afcb-e61607c04be3", "username": "pepsidawg00"}
 	],
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"gametype": "DTM",
 	"teams": [
 		{
@@ -136,7 +136,7 @@
 				"commands": [
 					"execute at @r run fill 0 8 -41 0 9 -41 minecraft:beacon replace minecraft:obsidian",
 					"execute at @r run fill 0 8 41 0 9 41 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 0 11 0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 11 0 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 11 0 100 1"]},
@@ -151,7 +151,7 @@
 				"commands": [
 					"execute at @r run fill 0 8 -41 0 9 -41 minecraft:coal_block replace minecraft:beacon",
 					"execute at @r run fill 0 8 41 0 9 41 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 0 11 0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 11 0 100 0"
 				]
 			}
 		]

--- a/DTM/Arctic Ruins/map.json
+++ b/DTM/Arctic Ruins/map.json
@@ -5,7 +5,7 @@
 		{"uuid": "0c44ca5a-6a42-49b7-81f2-58dc6d2ae3e9", "username": "Xerocoles"},
 		{"uuid": "3a64dcf4-5d71-4664-80bf-4e5c54e41b86", "username": "Zaquez"}
 	],
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"gametype": "DTM",
 	"teams": [
 		{
@@ -67,8 +67,8 @@
 				"commands": [
 					"execute at @r run fill 211 13 94 213 17 96 minecraft:coal_block replace minecraft:gold_block",
 					"execute at @r run fill 211 13 176 213 17 178 minecraft:coal_block replace minecraft:gold_block",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 212 15 95 100 0",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 212 15 177 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 212 15 95 100 0",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 212 15 177 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to packed ice.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 212 15 95 100 1", "execute at @r run playsound minecraft:block.note_block.hat master @a 212 15 177 100 1"]},
@@ -83,8 +83,8 @@
 				"commands": [
 					"execute at @r run fill 211 13 94 213 17 96 minecraft:packed_ice replace minecraft:coal_block",
 					"execute at @r run fill 211 13 176 213 17 178 minecraft:packed_ice replace minecraft:coal_block",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 212 15 95 100 0",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 212 15 177 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 212 15 95 100 0",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 212 15 177 100 0"
 				]
 			}
 		]

--- a/DTM/Coral Reef/map.json
+++ b/DTM/Coral Reef/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "38ab65dd-95f9-406f-917c-6accc995421f", "username": "GoldenOre"}
 	],
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"gametype": "DTM",
 	"teams": [
 		{
@@ -121,7 +121,7 @@
 				"commands": [
 					"execute at @r run fill 381 17 -665 381 19 -665 beacon replace obsidian",
 					"execute at @r run fill 434 17 -555 434 19 -555 beacon replace obsidian",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 407.5 20 -610 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 407.5 20 -610 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 407.5 20 -610 100 1"]},
@@ -136,7 +136,7 @@
 				"commands": [
 					"execute at @r run fill 381 17 -665 381 19 -665 coal_block replace beacon",
 					"execute at @r run fill 434 17 -555 434 19 -555 coal_block replace beacon",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 407.5 20 -610 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 407.5 20 -610 100 0"
 				]
 			}
 		]

--- a/DTM/Iris DTM/map.json
+++ b/DTM/Iris DTM/map.json
@@ -3,7 +3,7 @@
     "authors": [
         {"uuid": "3a549b18-08ed-4756-a78c-b34d29a4fd87", "username": "Torn_Ares"}
     ],
-    "version": "1.4.4",
+    "version": "1.4.5",
     "gametype": "DTM",
     "respawn": {
         "rules": [
@@ -119,7 +119,7 @@
                 "commands": [
                     "execute at @r run fill -63 31 -129 -63 33 -129 minecraft:beacon replace minecraft:obsidian",
                     "execute at @r run fill 29 31 -129 29 33 -129 minecraft:beacon replace minecraft:obsidian",
-                    "execute at @r run playsound minecraft:block.beacon.deactivate master @a -17 35 -129 100 0"
+                    "execute at @r run playsound minecraft:entity.elder_guardian.curse master @a -17 35 -129 100 0"
                 ]
             },
             {"message": "&61 minute until the monuments change to &l&4coal blocks&r&6.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a -17 35 -129 100 1"]},
@@ -134,7 +134,7 @@
                 "commands": [
                     "execute at @r run fill -63 31 -129 -63 33 -129 minecraft:coal_block replace minecraft:beacon",
                     "execute at @r run fill 29 31 -129 29 33 -129 minecraft:coal_block replace minecraft:beacon",
-                    "execute at @r run playsound minecraft:block.beacon.deactivate master @a -17 35 -129 100 0"
+                    "execute at @r run playsound minecraft:entity.elder_guardian.curse master @a -17 35 -129 100 0"
                 ]
             }
         ]

--- a/DTM/Loyalty DTM/map.json
+++ b/DTM/Loyalty DTM/map.json
@@ -4,7 +4,7 @@
 		{"uuid": "130be12a-f3b9-4b7d-ad39-7b45e84d3d0f", "username": "Veiyl"},
 		{"uuid": "36dc036a-dfbc-4627-b66a-501223f08075", "username": "ieatboulders2"}
 	],
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"gametype": "DTM",
 	"teams": [
 		{
@@ -136,7 +136,7 @@
 					"execute at @r run fill -290 27 1192 -290 28 1192 minecraft:beacon replace minecraft:obsidian",
 					"execute at @r run fill -342 27 1154 -342 28 1154 minecraft:beacon replace minecraft:obsidian",
 					"execute at @r run fill -342 27 1192 -342 28 1192 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a -316 5 1173 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a -316 5 1173 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a -316 5 1173 100 1"]},
@@ -153,7 +153,7 @@
 					"execute at @r run fill -290 27 1192 -290 28 1192 minecraft:coal_block replace minecraft:beacon",
 					"execute at @r run fill -342 27 1154 -342 28 1154 minecraft:coal_block replace minecraft:beacon",
 					"execute at @r run fill -342 27 1192 -342 28 1192 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a -316 5 1173 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a -316 5 1173 100 0"
 				]
 			}
 		]

--- a/DTM/Molendinis/map.json
+++ b/DTM/Molendinis/map.json
@@ -4,7 +4,7 @@
 		{"uuid": "36dc036a-dfbc-4627-b66a-501223f08075", "username": "bend"},
 		{"uuid": "105f6a09-f533-412b-93cb-501601763c11", "username": "JTr"}
 	],
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"gametype": "DTM",
 	"teams": [
 		{
@@ -138,7 +138,7 @@
 				"commands": [
 					"execute at @r run fill -195 7 35 -195 9 35 beacon replace obsidian",
 					"execute at @r run fill -48 7 46 -48 9 46 beacon replace obsidian",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a -122.5 10 41.0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a -122.5 10 41.0 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a -122.5 10 41.0 100 1"]},
@@ -153,7 +153,7 @@
 				"commands": [
 					"execute at @r run fill -195 7 35 -195 9 35 coal_block replace beacon",
 					"execute at @r run fill -48 7 46 -48 9 46 coal_block replace beacon",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a -122.5 10 41.0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a -122.5 10 41.0 100 0"
 				]
 			}
 		]

--- a/DTM/Sunrise Over Lava/map.json
+++ b/DTM/Sunrise Over Lava/map.json
@@ -31,7 +31,7 @@
 			{
 				"name": "Right Monument",
 				"teams": ["water"],
-				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"materials": ["obsidian", "end stone"],
 				"region": {
 					"min": "45, 8, -51",
 					"max": "46, 6, -50"
@@ -41,7 +41,7 @@
 			{
 				"name": "Left Monument",
 				"teams": ["water"],
-				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"materials": ["obsidian", "end stone"],
 				"region": {
 					"min": "-45, 8, -51",
 					"max": "-44, 6, -50"
@@ -51,7 +51,7 @@
 			{
 				"name": "Right Monument",
 				"teams": ["fire"],
-				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"materials": ["obsidian", "end stone"],
 				"region": {
 					"min": "-45, 8, 51",
 					"max": "-44, 6, 52"
@@ -61,7 +61,7 @@
 			{
 				"name": "Left Monument",
 				"teams": ["fire"],
-				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"materials": ["obsidian", "end stone"],
 				"region": {
 					"min": "45, 8, 51",
 					"max": "46, 6, 52"
@@ -72,54 +72,20 @@
 	},
 	"time": {
 		"broadcasts": [
-			{"message": "&61 minute until the monuments change to &l&4beacons&r&6!", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&620 seconds until the monuments change to &l&4beacons&r&6!", "interval": 880, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&63 seconds until the monuments change!", "interval": 897, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&62 seconds until the monuments change!", "interval": 898, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&61 second until the monuments change!", "interval": 899, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{
-				"message": "&6The monuments have changed to &l&4beacons&r&6.",
-				"interval": 900,
-				"repeat": false,
-				"commands": [
-					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run fill -45 6 51 -45 7 51 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run fill 45 6 51 45 7 51 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
-				]
-			},
-			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6!", "interval": 1140, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&620 seconds until the monuments change to &l&4coal blocks&r&6!", "interval": 1180, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&63 seconds until the monuments change!", "interval": 1197, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&62 seconds until the monuments change!", "interval": 1198, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&61 second until the monuments change!", "interval": 1199, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{
-				"message": "&6The monuments have changed to &l&4coal blocks&r&6.",
-				"interval": 1200,
-				"repeat": false,
-				"commands": [
-					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run fill -45 6 51 -45 7 51 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run fill 45 6 51 45 7 51 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
-				]
-			},
-			{"message": "&61 minute until the monuments change to &l&4black terracotta&r&6!", "interval": 1740, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
-			{"message": "&620 seconds until the monuments change to &l&4black terracotta&r&6!", "interval": 1780, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 minute until the monuments change to &l&4end stone&r&6!", "interval": 1740, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4end stone&r&6!", "interval": 1780, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
 			{"message": "&63 seconds until the monuments change!", "interval": 1797, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
 			{"message": "&62 seconds until the monuments change!", "interval": 1798, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
 			{"message": "&61 second until the monuments change!", "interval": 1799, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
 			{
-				"message": "&6The monuments have changed to &l&4black terracotta&r&6.",
+				"message": "&6The monuments have changed to &l&4end stone&r&6.",
 				"interval": 1800,
 				"repeat": false,
 				"commands": [
-					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
-					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
-					"execute at @r run fill -45 6 51 -45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
-					"execute at @r run fill 45 6 51 45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:end_stone replace minecraft:obsidian",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:end_stone replace minecraft:obsidian",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:end_stone replace minecraft:obsidian",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:end_stone replace minecraft:obsidian",
 					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
 				]
 			}

--- a/DTM/Sunrise Over Lava/map.json
+++ b/DTM/Sunrise Over Lava/map.json
@@ -165,7 +165,7 @@
 	],
 	"itemremove": [
 		"stone sword", "bow", "diamond pickaxe", "iron shovel", "glass", "oak log", "cooked cod", "arrow",
-		"oak planks", "obsidian", "end stone", "blue terracotta", "red terracotta", "blue stained glass", "red stained glass", "string", "wheat seeds",
+		"oak planks", "obsidian", "blue terracotta", "red terracotta", "blue stained glass", "red stained glass", "string", "wheat seeds", "golden apple",
 		{
 			"type": "leather helmet",
 			"drop": true

--- a/DTM/Sunrise Over Lava/map.json
+++ b/DTM/Sunrise Over Lava/map.json
@@ -1,217 +1,227 @@
 {
-    "name": "Sunrise Over Lava",
-    "authors": [
-        {"uuid": "ef4ea031-998f-4ec9-b7b6-1bdd428bcef8", "username": "Plastix"}
-    ],
-    "version": "2.0.4",
-    "gametype": "DTM",
-    "teams": [
-        {
-            "id": "fire",
-            "name": "Fire Nation",
-            "color": "dark_red",
-            "min": 1,
-            "max": 16
-        },
-        {
-            "id": "water",
-            "name": "Water Nation",
-            "color": "blue",
-            "min": 1,
-            "max": 16
-        }
-    ],
-    "spawns": [
-        {"teams": ["spectators"], "coords": "-44.5, 35, 0.5, -90"},
-        {"teams": ["fire"], "coords": "0.5, 3, 80.5, 180"},
-        {"teams": ["water"], "coords": "0.5, 3, -79.5"}
-    ],
-    "dtm": {
-        "monuments": [
-            {
-                "name": "Right Monument",
-                "teams": ["water"],
-                "materials": ["obsidian", "end stone"],
-                "region": {
-                    "min": "45, 8, -51",
-                    "max": "46, 6, -50"
-                },
-                "health": 2
-            },
-            {
-                "name": "Left Monument",
-                "teams": ["water"],
-                "materials": ["obsidian", "end stone"],
-                "region": {
-                    "min": "-45, 8, -51",
-                    "max": "-44, 6, -50"
-                },
-                "health": 2
-            },
-            {
-                "name": "Right Monument",
-                "teams": ["fire"],
-                "materials": ["obsidian", "end stone"],
-                "region": {
-                    "min": "-45, 8, 51",
-                    "max": "-44, 6, 52"
-                },
-                "health": 2
-            },
-            {
-                "name": "Left Monument",
-                "teams": ["fire"],
-                "materials": ["obsidian", "end stone"],
-                "region": {
-                    "min": "45, 8, 51",
-                    "max": "46, 6, 52"
-                },
-                "health": 2
-            }
-        ]
-    },
-    "time": {
-        "broadcasts": [
-            {
-                "message": "&61 minute until the monuments change to &l&4end stone&r&6!",
-                "interval": 1740,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&620 seconds until the monuments change!",
-                "interval": 1780,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&63 seconds until the monuments change!",
-                "interval": 1797,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&62 seconds until the monuments change!",
-                "interval": 1798,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&61 second until the monuments change!",
-                "interval": 1799,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&6The monuments have changed to &l&4end stone&r&6.",
-                "interval": 1800,
-                "repeat": false,
-                "commands": [
-                    "execute at @r run fill 45 6 -51 45 7 -51 minecraft:end_stone replace minecraft:obsidian",
-                    "execute at @r run fill -45 6 -51 -45 7 -51 minecraft:end_stone replace minecraft:obsidian",
-                    "execute at @r run fill -45 6 51 -45 7 51 minecraft:end_stone replace minecraft:obsidian",
-                    "execute at @r run fill 45 6 51 45 7 51 minecraft:end_stone replace minecraft:obsidian"
-                ]
-            }
-        ]
-    },
-    "kits": [
-        {
-            "name": "Default",
-            "items": [
-                {"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
-                {"type": "item", "material": "bow", "enchantments": ["infinity:1"], "slot": 1, "unbreakable": true},
-                {"type": "item", "material": "diamond pickaxe", "slot": 2, "unbreakable": true},
-                {"type": "item", "material": "iron shovel", "enchantments": ["efficiency:1"], "slot": 3, "unbreakable": true},
+	"name": "Sunrise Over Lava",
+	"authors": [
+		{"uuid": "ef4ea031-998f-4ec9-b7b6-1bdd428bcef8", "username": "Plastix"}
+	],
+	"version": "2.0.5",
+	"gametype": "DTM",
+	"teams": [
+		{
+			"id": "fire",
+			"name": "Fire Nation",
+			"color": "dark red",
+			"min": 1,
+			"max": 16
+		},
+		{
+			"id": "water",
+			"name": "Water Nation",
+			"color": "blue",
+			"min": 1,
+			"max": 16
+		}
+	],
+	"spawns": [
+		{"teams": ["spectators"], "coords": "-44.5, 35, 0.5, -90"},
+		{"teams": ["fire"], "coords": "0.5, 3, 80.5, 180"},
+		{"teams": ["water"], "coords": "0.5, 3, -79.5"}
+	],
+	"dtm": {
+		"monuments": [
+			{
+				"name": "Right Monument",
+				"teams": ["water"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "45, 8, -51",
+					"max": "46, 6, -50"
+				},
+				"health": 2
+			},
+			{
+				"name": "Left Monument",
+				"teams": ["water"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "-45, 8, -51",
+					"max": "-44, 6, -50"
+				},
+				"health": 2
+			},
+			{
+				"name": "Right Monument",
+				"teams": ["fire"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "-45, 8, 51",
+					"max": "-44, 6, 52"
+				},
+				"health": 2
+			},
+			{
+				"name": "Left Monument",
+				"teams": ["fire"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "45, 8, 51",
+					"max": "46, 6, 52"
+				},
+				"health": 2
+			}
+		]
+	},
+	"time": {
+		"broadcasts": [
+			{"message": "&61 minute until the monuments change to &l&4beacons&r&6!", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4beacons&r&6!", "interval": 880, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&63 seconds until the monuments change!", "interval": 897, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&62 seconds until the monuments change!", "interval": 898, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 second until the monuments change!", "interval": 899, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{
+				"message": "&6The monuments have changed to &l&4beacons&r&6.",
+				"interval": 900,
+				"repeat": false,
+				"commands": [
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
+				]
+			},
+			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6!", "interval": 1140, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4coal blocks&r&6!", "interval": 1180, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&63 seconds until the monuments change!", "interval": 1197, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&62 seconds until the monuments change!", "interval": 1198, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 second until the monuments change!", "interval": 1199, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{
+				"message": "&6The monuments have changed to &l&4coal blocks&r&6.",
+				"interval": 1200,
+				"repeat": false,
+				"commands": [
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
+				]
+			},
+			{"message": "&61 minute until the monuments change to &l&4black terracotta&r&6!", "interval": 1740, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4black terracotta&r&6!", "interval": 1780, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&63 seconds until the monuments change!", "interval": 1797, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&62 seconds until the monuments change!", "interval": 1798, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 second until the monuments change!", "interval": 1799, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{
+				"message": "&6The monuments have changed to &l&4black terracotta&r&6.",
+				"interval": 1800,
+				"repeat": false,
+				"commands": [
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
+				]
+			}
+		]
+	},
+	"kits": [
+		{
+			"name": "Default",
+			"items": [
+				{"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
+				{"type": "item", "material": "bow", "enchantments": ["infinity:1"], "slot": 1, "unbreakable": true},
+				{"type": "item", "material": "diamond pickaxe", "slot": 2, "unbreakable": true},
+				{"type": "item", "material": "iron shovel", "enchantments": ["efficiency:1"], "slot": 3, "unbreakable": true},
 
-                {"type": "item", "material": "cooked cod", "slot": 8, "amount": 32},
-                {"type": "item", "material": "arrow", "slot": 28, "amount": 1},
+				{"type": "item", "material": "cooked cod", "slot": 8, "amount": 32},
+				{"type": "item", "material": "arrow", "slot": 28, "amount": 1},
 
-                {"type": "item", "material": "leather helmet", "slot": "helmet", "unbreakable": true},
-                {"type": "item", "material": "leather chestplate", "slot": "chestplate", "enchantments": ["projectile_protection:2"], "unbreakable": true},
-                {"type": "item", "material": "leather leggings", "slot": "leggings", "unbreakable": true},
-                {"type": "item", "material": "leather boots", "slot": "boots", "unbreakable": true}
-            ],
-            "effects": [
-                {"type": "DAMAGE_RESISTANCE", "duration": 90, "amplifier": 10000, "particles": false}
-            ]
-        },
-        {
-            "name": "Fire Kit",
-            "teams": ["fire"],
-            "items": [
-                {"type": "item", "material": "red terracotta", "slot": 4, "amount": 64},
-                {"type": "item", "material": "red stained glass", "slot": 5, "amount": 32}
-            ]
-        },
-        {
-            "name": "Water Kit",
-            "teams": ["water"],
-            "items": [
-                {"type": "item", "material": "blue terracotta", "slot": 4, "amount": 64},
-                {"type": "item", "material": "blue stained glass", "slot": 5, "amount": 32}
-            ]
-        }
-    ],
-    "itemremove": [
-        "stone sword", "bow", "diamond pickaxe", "iron shovel", "glass", "oak log", "cooked cod", "arrow",
-        "oak planks", "obsidian", "end stone", "blue terracotta", "red terracotta", "blue stained glass", "red stained glass", "string", "wheat seeds",
-        {
-            "type": "leather helmet",
-            "drop": true
-        },
-        {
-            "type": "leather chestplate",
-            "drop": true
-        },
-        {
-            "type": "leather leggings",
-            "drop": true
-        },
-        {
-            "type": "leather boots",
-            "drop": true
-        }
-    ],
-    "killstreaks": [
-        {
-            "count": 1,
-            "repeat": true,
-            "actions": {
-                "items": [
-                    {"material": "golden apple", "amount": 1}
-                ]
-            }
-        }
-    ],
-    "regions": [
-        {"id": "fire-spawn-protection", "type": "cylinder", "base": "0.5, 0, 80.5", "radius": 9.5, "height": 25},
-        {"id": "water-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25 },
-        {"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25 }
-    ],
-    "filters": [
-        {
-            "type": "build", "evaluate": "deny", "teams": ["fire", "water"],
-            "regions": ["fire-spawn-protection", "water-spawn-protection"],
-            "message": "&cYou are not allowed to modify terrain here."
-        },
-        {"type": "enter", "evaluate": "deny", "teams": ["fire"], "regions": ["water-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
-        {"type": "enter", "evaluate": "deny", "teams": ["water"], "regions": ["fire-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
-        {
-            "type": "build", "evaluate": "deny", "inverted": true, "teams": ["fire", "water"],
-            "regions": ["playable"], "message": "&cYou cannot build outside of the map."
-        }
-    ],
-    "crafting": {
-        "remove": [
-            "oak boat",
-            "jungle boat",
-            "bucket"
-        ]
-    },
-    "gamerules": {
-        "doFireTick": true,
-        "doDaylightCycle": true
-    },
+				{"type": "item", "material": "leather helmet", "slot": "helmet", "unbreakable": true},
+				{"type": "item", "material": "leather chestplate", "slot": "chestplate", "enchantments": ["projectile_protection:2"], "unbreakable": true},
+				{"type": "item", "material": "leather leggings", "slot": "leggings", "unbreakable": true},
+				{"type": "item", "material": "leather boots", "slot": "boots", "unbreakable": true}
+			],
+			"effects": [
+				{"type": "DAMAGE_RESISTANCE", "duration": 90, "amplifier": 10000, "particles": false}
+			]
+		},
+		{
+			"name": "Fire Kit",
+			"teams": ["fire"],
+			"items": [
+				{"type": "item", "material": "red terracotta", "slot": 4, "amount": 64},
+				{"type": "item", "material": "red stained glass", "slot": 5, "amount": 32}
+			]
+		},
+		{
+			"name": "Water Kit",
+			"teams": ["water"],
+			"items": [
+				{"type": "item", "material": "blue terracotta", "slot": 4, "amount": 64},
+				{"type": "item", "material": "blue stained glass", "slot": 5, "amount": 32}
+			]
+		}
+	],
+	"itemremove": [
+		"stone sword", "bow", "diamond pickaxe", "iron shovel", "glass", "oak log", "cooked cod", "arrow",
+		"oak planks", "obsidian", "end stone", "blue terracotta", "red terracotta", "blue stained glass", "red stained glass", "string", "wheat seeds",
+		{
+			"type": "leather helmet",
+			"drop": true
+		},
+		{
+			"type": "leather chestplate",
+			"drop": true
+		},
+		{
+			"type": "leather leggings",
+			"drop": true
+		},
+		{
+			"type": "leather boots",
+			"drop": true
+		}
+	],
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "amount": 1}
+				]
+			}
+		}
+	],
+	"regions": [
+		{"id": "fire-spawn-protection", "type": "cylinder", "base": "0.5, 0, 80.5", "radius": 9.5, "height": 25},
+		{"id": "water-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25 },
+		{"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25 }
+	],
+	"filters": [
+		{
+			"type": "build", "evaluate": "deny", "teams": ["fire", "water"],
+			"regions": ["fire-spawn-protection", "water-spawn-protection"],
+			"message": "&cYou are not allowed to modify terrain here."
+		},
+		{"type": "enter", "evaluate": "deny", "teams": ["fire"], "regions": ["water-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
+		{"type": "enter", "evaluate": "deny", "teams": ["water"], "regions": ["fire-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
+		{
+			"type": "build", "evaluate": "deny", "inverted": true, "teams": ["fire", "water"],
+			"regions": ["playable"], "message": "&cYou cannot build outside of the map."
+		}
+	],
+	"crafting": {
+		"remove": [
+			"oak boat",
+			"jungle boat",
+			"bucket"
+		]
+	},
+	"gamerules": {
+		"doFireTick": true,
+		"doDaylightCycle": true
+	},
 	"buildHeight": 19
 }

--- a/DTM/Sunrise Over Lava/map.json
+++ b/DTM/Sunrise Over Lava/map.json
@@ -196,7 +196,16 @@
 	],
 	"regions": [
 		{"id": "fire-spawn-protection", "type": "cylinder", "base": "0.5, 0, 80.5", "radius": 9.5, "height": 25},
-		{"id": "water-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25 },
+		{"id": "water-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25},
+		{
+			"id": "monument-protection", "type": "meta",
+			"regions": [
+				{"min": "45, 6, -51", "max": "45, 7, -51"},
+				{"min": "-45, 6, -51", "max": "-45, 7, -51"},
+				{"min": "-45, 6, 51", "max": "-45, 7, 51"},
+				{"min": "45, 6, 51", "max": "45, 7, 51"}
+			]
+		},
 		{"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25 }
 	],
 	"filters": [
@@ -204,6 +213,10 @@
 			"type": "build", "evaluate": "deny", "teams": ["fire", "water"],
 			"regions": ["fire-spawn-protection", "water-spawn-protection"],
 			"message": "&cYou are not allowed to modify terrain here."
+		},
+		{
+			"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"],
+			"regions": ["monument-protection"]
 		},
 		{"type": "enter", "evaluate": "deny", "teams": ["fire"], "regions": ["water-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
 		{"type": "enter", "evaluate": "deny", "teams": ["water"], "regions": ["fire-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},

--- a/DTM/Sunrise Over Paradise/map.json
+++ b/DTM/Sunrise Over Paradise/map.json
@@ -182,14 +182,27 @@
 	],
 	"regions": [
 		{"id": "red-spawn-protection", "type": "cylinder", "base": "0.5, 0, 80.5", "radius": 9.5, "height": 25},
-		{"id": "blue-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25 },
-		{"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25 }
+		{"id": "blue-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25},
+		{
+			"id": "monument-protection", "type": "meta",
+			"regions": [
+				{"min": "45, 6, -51", "max": "45, 7, -51"},
+				{"min": "-45, 6, -51", "max": "-45, 7, -51"},
+				{"min": "-45, 6, 51", "max": "-45, 7, 51"},
+				{"min": "45, 6, 51", "max": "45, 7, 51"}
+			]
+		},
+		{"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25}
 	],
 	"filters": [
 		{
 			"type": "build", "evaluate": "deny", "teams": ["red", "blue"],
 			"regions": ["red-spawn-protection", "blue-spawn-protection"],
 			"message": "&cYou are not allowed to modify terrain here."
+		},
+		{
+			"type": "block-explode", "evaluate": "deny", "teams": ["blue", "red"],
+			"regions": ["monument-protection"]
 		},
 		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
 		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},

--- a/DTM/Sunrise Over Paradise/map.json
+++ b/DTM/Sunrise Over Paradise/map.json
@@ -151,7 +151,7 @@
 	],
 	"itemremove": [
 		"stone sword", "bow", "diamond pickaxe", "iron axe", "glass", "oak log", "cooked cod", "arrow",
-		"oak planks", "obsidian", "beacon", "black_terracotta", "string", "wheat seeds",
+		"oak planks", "obsidian", "beacon", "black terracotta", "string", "wheat seeds", "golden apple",
 		{
 			"type": "leather helmet",
 			"drop": true

--- a/DTM/Sunrise Over Paradise/map.json
+++ b/DTM/Sunrise Over Paradise/map.json
@@ -1,286 +1,212 @@
 {
-    "name": "Sunrise Over Paradise",
-    "authors": [
-        {"uuid": "ef4ea031-998f-4ec9-b7b6-1bdd428bcef8", "username": "Plastix"}
-    ],
-    "version": "1.3.6",
-    "gametype": "DTM",
-    "teams": [
-        {
-            "id": "red",
-            "name": "Red",
-            "color": "dark_red",
-            "min": 1,
-            "max": 16
-        },
-        {
-            "id": "blue",
-            "name": "Blue",
-            "color": "blue",
-            "min": 1,
-            "max": 16
-        }
-    ],
-    "spawns": [
-        {"teams": ["spectators"], "coords": "-44.5, 35, 0.5, -90"},
-        {"teams": ["red"], "coords": "0.5, 3, 80.5, 180"},
-        {"teams": ["blue"], "coords": "0.5, 3, -79.5"}
-    ],
-    "dtm": {
-        "monuments": [
-            {
-                "name": "Right Monument",
-                "teams": ["blue"],
-                "materials": ["obsidian", "beacon", "black_terracotta"],
-                "region": {
-                    "min": "45, 8, -51",
-                    "max": "46, 6, -50"
-                },
-                "health": 2
-            },
-            {
-                "name": "Left Monument",
-                "teams": ["blue"],
-                "materials": ["obsidian", "beacon", "black_terracotta"],
-                "region": {
-                    "min": "-45, 8, -51",
-                    "max": "-44, 6, -50"
-                },
-                "health": 2
-            },
-            {
-                "name": "Right Monument",
-                "teams": ["red"],
-                "materials": ["obsidian", "beacon", "black_terracotta"],
-                "region": {
-                    "min": "-45, 8, 51",
-                    "max": "-44, 6, 52"
-                },
-                "health": 2
-            },
-            {
-                "name": "Left Monument",
-                "teams": ["red"],
-                "materials": ["obsidian", "beacon", "black_terracotta"],
-                "region": {
-                    "min": "45, 8, 51",
-                    "max": "46, 6, 52"
-                },
-                "health": 2
-            }
-        ]
-    },
-    "time": {
-        "broadcasts": [
-            {
-                "message": "&61 minute until the monuments change to &l&4beacons&r&6!",
-                "interval": 840,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&620 seconds until the monuments change!",
-                "interval": 880,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&63 seconds until the monuments change!",
-                "interval": 897,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&62 seconds until the monuments change!",
-                "interval": 898,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&61 second until the monuments change!",
-                "interval": 899,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&6The monuments have changed to &l&4beacons&r&6.",
-                "interval": 900,
-                "repeat": false,
-                "commands": [
-                    "execute at @r run fill 45 6 -51 45 7 -51 minecraft:beacon replace minecraft:obsidian",
-                    "execute at @r run fill -45 6 -51 -45 7 -51 minecraft:beacon replace minecraft:obsidian",
-                    "execute at @r run fill -45 6 51 -45 7 51 minecraft:beacon replace minecraft:obsidian",
-                    "execute at @r run fill 45 6 51 45 7 51 minecraft:beacon replace minecraft:obsidian"
-                ]
-            },
+	"name": "Sunrise Over Paradise",
+	"authors": [
+		{"uuid": "ef4ea031-998f-4ec9-b7b6-1bdd428bcef8", "username": "Plastix"}
+	],
+	"version": "1.3.7",
+	"gametype": "DTM",
+	"teams": [
+		{
+			"id": "red",
+			"name": "Red",
+			"color": "dark red",
+			"min": 1,
+			"max": 16
+		},
+		{
+			"id": "blue",
+			"name": "Blue",
+			"color": "blue",
+			"min": 1,
+			"max": 16
+		}
+	],
+	"spawns": [
+		{"teams": ["spectators"], "coords": "-44.5, 35, 0.5, -90"},
+		{"teams": ["red"], "coords": "0.5, 3, 80.5, 180"},
+		{"teams": ["blue"], "coords": "0.5, 3, -79.5"}
+	],
+	"dtm": {
+		"monuments": [
+			{
+				"name": "Right Monument",
+				"teams": ["blue"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "45, 8, -51",
+					"max": "46, 6, -50"
+				},
+				"health": 2
+			},
+			{
+				"name": "Left Monument",
+				"teams": ["blue"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "-45, 8, -51",
+					"max": "-44, 6, -50"
+				},
+				"health": 2
+			},
+			{
+				"name": "Right Monument",
+				"teams": ["red"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "-45, 8, 51",
+					"max": "-44, 6, 52"
+				},
+				"health": 2
+			},
+			{
+				"name": "Left Monument",
+				"teams": ["red"],
+				"materials": ["obsidian", "beacon", "coal block", "black terracotta"],
+				"region": {
+					"min": "45, 8, 51",
+					"max": "46, 6, 52"
+				},
+				"health": 2
+			}
+		]
+	},
+	"time": {
+		"broadcasts": [
+			{"message": "&61 minute until the monuments change to &l&4beacons&r&6!", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4beacons&r&6!", "interval": 880, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&63 seconds until the monuments change!", "interval": 897, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&62 seconds until the monuments change!", "interval": 898, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 second until the monuments change!", "interval": 899, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{
+				"message": "&6The monuments have changed to &l&4beacons&r&6.",
+				"interval": 900,
+				"repeat": false,
+				"commands": [
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:beacon replace minecraft:obsidian",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
+				]
+			},
+			{"message": "&61 minute until the monuments change to &l&4coal blocks&r&6!", "interval": 1140, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4coal blocks&r&6!", "interval": 1180, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&63 seconds until the monuments change!", "interval": 1197, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&62 seconds until the monuments change!", "interval": 1198, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 second until the monuments change!", "interval": 1199, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{
+				"message": "&6The monuments have changed to &l&4coal blocks&r&6.",
+				"interval": 1200,
+				"repeat": false,
+				"commands": [
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:coal_block replace minecraft:beacon",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
+				]
+			},
+			{"message": "&61 minute until the monuments change to &l&4black terracotta&r&6!", "interval": 1740, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&620 seconds until the monuments change to &l&4black terracotta&r&6!", "interval": 1780, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&63 seconds until the monuments change!", "interval": 1797, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&62 seconds until the monuments change!", "interval": 1798, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{"message": "&61 second until the monuments change!", "interval": 1799, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 0 10 0 100 1"]},
+			{
+				"message": "&6The monuments have changed to &l&4black terracotta&r&6.",
+				"interval": 1800,
+				"repeat": false,
+				"commands": [
+					"execute at @r run fill 45 6 -51 45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill -45 6 -51 -45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill -45 6 51 -45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run fill 45 6 51 45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 0 10 0 100 0"
+				]
+			}
+		]
+	},
+	"kits": [
+		{
+			"name": "Default",
+			"items": [
+				{"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
+				{"type": "item", "material": "bow", "enchantments": ["infinity:1"], "slot": 1, "unbreakable": true},
+				{"type": "item", "material": "diamond pickaxe", "slot": 2, "unbreakable": true},
+				{"type": "item", "material": "iron axe", "enchantments": ["efficiency:1"], "slot": 3, "unbreakable": true},
 
-            {
-                "message": "&61 minute until the monuments change to &l&4coal blocks&r&6!",
-                "interval": 1140,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&620 seconds until the monuments change!",
-                "interval": 1180,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&63 seconds until the monuments change!",
-                "interval": 1197,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&62 seconds until the monuments change!",
-                "interval": 1198,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&61 second until the monuments change!",
-                "interval": 1199,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&6The monuments have changed to &l&4coal blocks&r&6.",
-                "interval": 1200,
-                "repeat": false,
-                "commands": [
-                    "execute at @r run fill 45 6 -51 45 7 -51 minecraft:coal_block replace minecraft:beacon",
-                    "execute at @r run fill -45 6 -51 -45 7 -51 minecraft:coal_block replace minecraft:beacon",
-                    "execute at @r run fill -45 6 51 -45 7 51 minecraft:coal_block replace minecraft:beacon",
-                    "execute at @r run fill 45 6 51 45 7 51 minecraft:coal_block replace minecraft:beacon"
-                ]
-            },
+				{"type": "item", "material": "oak log", "slot": 4, "amount": 32},
+				{"type": "item", "material": "glass", "slot": 5, "amount": 32},
+				{"type": "item", "material": "cooked cod", "slot": 8, "amount": 32},
+				{"type": "item", "material": "arrow", "slot": 28, "amount": 1},
 
-            {
-                "message": "&61 minute until the monuments change to black terracotta!",
-                "interval": 1740,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&620 seconds until the monuments change!",
-                "interval": 1780,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&63 seconds until the monuments change!",
-                "interval": 1797,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&62 seconds until the monuments change!",
-                "interval": 1798,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&61 second until the monuments change!",
-                "interval": 1799,
-                "repeat": false,
-                "commands": []
-            },
-            {
-                "message": "&6The monuments have changed to &l&4black terracotta&r&6.",
-                "interval": 1800,
-                "repeat": false,
-                "commands": [
-                    "execute at @r run fill 45 6 -51 45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
-                    "execute at @r run fill -45 6 -51 -45 7 -51 minecraft:black_terracotta replace minecraft:coal_block",
-                    "execute at @r run fill -45 6 51 -45 7 51 minecraft:black_terracotta replace minecraft:coal_block",
-                    "execute at @r run fill 45 6 51 45 7 51 minecraft:black_terracotta replace minecraft:coal_block"
-                ]
-            }
-        ]
-    },
-    "kits": [
-        {
-            "name": "Default",
-            "items": [
-                {"type": "item", "material": "stone sword", "slot": 0, "unbreakable": true},
-                {"type": "item", "material": "bow", "enchantments": ["infinity:1"], "slot": 1, "unbreakable": true},
-                {"type": "item", "material": "diamond pickaxe", "slot": 2, "unbreakable": true},
-                {"type": "item", "material": "iron axe", "enchantments": ["efficiency:1"], "slot": 3, "unbreakable": true},
-
-                {"type": "item", "material": "oak log", "slot": 4, "amount": 32},
-                {"type": "item", "material": "glass", "slot": 5, "amount": 32},
-                {"type": "item", "material": "cooked cod", "slot": 8, "amount": 32},
-                {"type": "item", "material": "arrow", "slot": 28, "amount": 1},
-
-                {"type": "item", "material": "leather helmet", "slot": "helmet", "unbreakable": true},
-                {"type": "item", "material": "leather chestplate", "slot": "chestplate", "enchantments": ["projectile_protection:2"], "unbreakable": true},
-                {"type": "item", "material": "leather leggings", "slot": "leggings", "unbreakable": true},
-                {"type": "item", "material": "leather boots", "slot": "boots", "unbreakable": true}
-            ],
-            "effects": [
-                {"type": "DAMAGE_RESISTANCE", "duration": 90, "amplifier": 10000, "particles": false}
-            ]
-        }
-    ],
-    "itemremove": [
-        "stone sword", "bow", "diamond pickaxe", "iron axe", "glass", "oak log", "cooked cod", "arrow",
-        "oak planks", "obsidian", "beacon", "black_terracotta", "string", "wheat seeds",
-        {
-            "type": "leather helmet",
-            "drop": true
-        },
-        {
-            "type": "leather chestplate",
-            "drop": true
-        },
-        {
-            "type": "leather leggings",
-            "drop": true
-        },
-        {
-            "type": "leather boots",
-            "drop": true
-        }
-    ],
-    "killstreaks": [
-        {
-            "count": 1,
-            "repeat": true,
-            "actions": {
-                "items": [
-                    {"material": "golden apple", "amount": 1}
-                ]
-            }
-        }
-    ],
-    "regions": [
-        {"id": "red-spawn-protection", "type": "cylinder", "base": "0.5, 0, 80.5", "radius": 9.5, "height": 25},
-        {"id": "blue-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25 },
-        {"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25 }
-    ],
-    "filters": [
-        {
-            "type": "build", "evaluate": "deny", "teams": ["red", "blue"],
-            "regions": ["red-spawn-protection", "blue-spawn-protection"],
-            "message": "&cYou are not allowed to modify terrain here."
-        },
-        {"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
-        {"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
-        {
-            "type": "build", "evaluate": "deny", "inverted": true, "teams": ["red", "blue"],
-            "regions": ["playable"], "message": "&cYou cannot build outside of the map."
-        }
-    ],
-    "crafting": {
-        "remove": [
-            "oak boat",
-            "jungle boat"
-        ]
-    },
-    "gamerules": {
-        "doFireTick": true,
-        "doDaylightCycle": true
-    },
-    "buildHeight": 19
+				{"type": "item", "material": "leather helmet", "slot": "helmet", "unbreakable": true},
+				{"type": "item", "material": "leather chestplate", "slot": "chestplate", "enchantments": ["projectile_protection:2"], "unbreakable": true},
+				{"type": "item", "material": "leather leggings", "slot": "leggings", "unbreakable": true},
+				{"type": "item", "material": "leather boots", "slot": "boots", "unbreakable": true}
+			],
+			"effects": [
+				{"type": "DAMAGE_RESISTANCE", "duration": 90, "amplifier": 10000, "particles": false}
+			]
+		}
+	],
+	"itemremove": [
+		"stone sword", "bow", "diamond pickaxe", "iron axe", "glass", "oak log", "cooked cod", "arrow",
+		"oak planks", "obsidian", "beacon", "black_terracotta", "string", "wheat seeds",
+		{
+			"type": "leather helmet",
+			"drop": true
+		},
+		{
+			"type": "leather chestplate",
+			"drop": true
+		},
+		{
+			"type": "leather leggings",
+			"drop": true
+		},
+		{
+			"type": "leather boots",
+			"drop": true
+		}
+	],
+	"killstreaks": [
+		{
+			"count": 1,
+			"repeat": true,
+			"actions": {
+				"items": [
+					{"material": "golden apple", "amount": 1}
+				]
+			}
+		}
+	],
+	"regions": [
+		{"id": "red-spawn-protection", "type": "cylinder", "base": "0.5, 0, 80.5", "radius": 9.5, "height": 25},
+		{"id": "blue-spawn-protection", "type": "cylinder", "base": "0.5, 0, -79.5", "radius": 9.5, "height": 25 },
+		{"id": "playable", "type": "cylinder", "base": "0.5, 0, 0.5", "radius": 101, "height": 25 }
+	],
+	"filters": [
+		{
+			"type": "build", "evaluate": "deny", "teams": ["red", "blue"],
+			"regions": ["red-spawn-protection", "blue-spawn-protection"],
+			"message": "&cYou are not allowed to modify terrain here."
+		},
+		{"type": "enter", "evaluate": "deny", "teams": ["red"], "regions": ["blue-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
+		{"type": "enter", "evaluate": "deny", "teams": ["blue"], "regions": ["red-spawn-protection"], "message": "&cYou may not enter the enemy spawn."},
+		{
+			"type": "build", "evaluate": "deny", "inverted": true, "teams": ["red", "blue"],
+			"regions": ["playable"], "message": "&cYou cannot build outside of the map."
+		}
+	],
+	"crafting": {
+		"remove": [
+			"oak boat",
+			"jungle boat"
+		]
+	},
+	"gamerules": {
+		"doFireTick": true,
+		"doDaylightCycle": true
+	},
+	"buildHeight": 19
 }

--- a/DTM/Warlock/map.json
+++ b/DTM/Warlock/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "e5953ddf-c1fc-4405-9ac9-6939631cd185", "username": "McSpider"}
 	],
-	"version": "1.4.6",
+	"version": "1.4.7",
 	"gametype": "DTM",
 	"teams": [
 		{
@@ -64,7 +64,7 @@
 				"commands": [
 					"execute at @r run fill 77 1 -37 77 2 -37 minecraft:beacon replace minecraft:obsidian",
 					"execute at @r run fill 77 1 37 77 2 37 minecraft:beacon replace minecraft:obsidian",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 77 6 0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 77 6 0 100 0"
 				]
 			},
 			{"message": "&61 minute until the monuments change to coal blocks.", "interval": 840, "repeat": false, "commands": ["execute at @r run playsound minecraft:block.note_block.hat master @a 77 6 0 100 1"]},
@@ -79,7 +79,7 @@
 				"commands": [
 					"execute at @r run fill 77 1 -37 77 2 -37 minecraft:coal_block replace minecraft:beacon",
 					"execute at @r run fill 77 1 37 77 2 37 minecraft:coal_block replace minecraft:beacon",
-					"execute at @r run playsound minecraft:block.beacon.deactivate master @a 77 6 0 100 0"
+					"execute at @r run playsound minecraft:entity.elder_guardian.curse master @a 77 6 0 100 0"
 				]
 			}
 		]


### PR DESCRIPTION
In older versions of the game, the beacon did not have unique sound effects. Because of this, players participating in older versions of the game don't receive audible notifications of the changes to the monuments.
This PR changes the beacon sound effect to the elder guardian curse sound effect (the one you get when it curses you with mining fatigue), which is not only available for 1.8 players but also sounds more dramatic. :)