### PR TITLE
Gelid 2 & Sarc - Increase target score

### DIFF
--- a/KOTH/Gelid 2/map.json
+++ b/KOTH/Gelid 2/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "f690a591-348b-482e-a18d-7779d0c0a28c", "username": "mitchiii"}
 	],
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"gametype": "KOTH",
 	"teams": [
 		{
@@ -27,7 +27,7 @@
 		{"teams": ["red"], "coords": "-318, 8, -6, 90"}
 	],
 	"points": {
-		"target": 300
+		"target": 1250
 	},
 	"koth": {
 		"hills": [

--- a/KOTH/Sarc/map.json
+++ b/KOTH/Sarc/map.json
@@ -3,7 +3,7 @@
 	"authors": [
 		{"uuid": "f690a591-348b-482e-a18d-7779d0c0a28c", "username": "mitchiii"}
 	],
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"gametype": "KOTH",
 	"teams": [
 		{
@@ -29,7 +29,7 @@
 		{"teams": ["red"], "coords": "-249.5, 6.0625, -245"}
 	],
 	"points": {
-		"target": 300
+		"target": 600
 	},
 	"koth": {
 		"hills": [


### PR DESCRIPTION
Gelid 2 & Sarc play for way too short, especially since they both have more than one hill.