### PR TITLE
Remove Equinox from the Small rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -52,7 +52,6 @@
 			"Desolate Gully",
 			"Downforce",
 			"Egypt",
-			"Equinox",
 			"Fracture DTM",
 			"Halcyon Holiday",
 			"Loyalty DTM",


### PR DESCRIPTION
Equinox should be removed from the Small rotation as it is much better suited for the other rotations it currently resides in. It's large, and is likely specifically made for a reasonably high player count. 

_From my experience playing this map on PGM, it's only played with around 20-40 players_

![image](https://user-images.githubusercontent.com/55336990/146317153-88e0d6f4-3b8b-48f0-bf52-0dd2ad858209.png)
