### PR TITLE
Remove Rampant from the Small rotation

### DIFF
--- a/rotation.json
+++ b/rotation.json
@@ -57,7 +57,6 @@
 			"Loyalty DTM",
 			"Oriental",
 			"Persisto",
-			"Rampant",
 			"Ricco Christmas",
 			"Rooted",
 			"Snowstone",


### PR DESCRIPTION
Rampant is simply too big of a map to be played in the Small rotation.
![image](https://user-images.githubusercontent.com/55336990/146324128-a7d852e5-7fcc-4859-9beb-004c85453658.png)