### PR TITLE
Tweak Rooted CTW itemremove

### DIFF
--- a/CTW/Rooted CTW/map.json
+++ b/CTW/Rooted CTW/map.json
@@ -3,7 +3,7 @@
     "authors": [
         {"uuid": "fe3608b7-d105-4029-8800-34b3147065b6", "username": "rockymine"}
     ],
-    "version": "2.2.3",
+    "version": "2.2.4",
     "gametype": "CTW",
     "teams": [
         {
@@ -87,8 +87,7 @@
         }
     ],
     "itemremove": [
-        "stone sword", "iron sword", "bow", "shears", "arrow", "stone axe", "iron axe", "iron pickaxe", "iron shovel", "iron helmet", "iron leggings", "iron boots", "stone", "dirt", "poppy", "wheat seeds", "oak sapling", "tall grass", "golden carrot", "apple", "flint",
-	"light blue wool", "light gray wool", "lime wool", "green wool",    
+        "stone sword", "bow", "iron pickaxe", "stone axe", "iron shovel", "oak leaves", "oak planks", "shears", "golden carrot", "cobweb", "arrow", "golden apple", "light blue wool", "light gray wool", "lime wool", "green wool",   
         {
             "type": "iron chestplate",
             "drop": true

--- a/CTW/Rooted CTW/map.json
+++ b/CTW/Rooted CTW/map.json
@@ -87,7 +87,8 @@
         }
     ],
     "itemremove": [
-        "stone sword", "bow", "iron pickaxe", "stone axe", "iron shovel", "oak leaves", "oak planks", "shears", "golden carrot", "cobweb", "arrow", "golden apple", "light blue wool", "light gray wool", "lime wool", "green wool",   
+        "stone sword", "iron sword", "bow", "oak leaves", "oak planks", "shears", "arrow", "stone axe", "iron axe", "iron pickaxe", "iron shovel", "iron helmet", "iron leggings", "iron boots", "stone", "dirt", "poppy", "wheat seeds", "oak sapling", "tall grass", "golden carrot", "cobweb", "apple", "golden apple", "flint",
+	"light blue wool", "light gray wool", "lime wool", "green wool",
         {
             "type": "iron chestplate",
             "drop": true


### PR DESCRIPTION
~~Apparently someone thought it was a good idea to itemremove tall grass, (regular) apple, seed, poppy, stone, and dirt?~~

I was mistaken in my original comment about the extra items in itemremove. I've re-added it back and also included some missing items from the kit in the list as well.